### PR TITLE
Enable plt.subplots style axes sharing; allow for custom keyword arguments to be passed to Axes constructor

### DIFF
--- a/ci/environment-py36.yml
+++ b/ci/environment-py36.yml
@@ -3,6 +3,7 @@ channels:
     - conda-forge
 dependencies:
     - python=3.6
+    - cartopy
     - jupyter
     - matplotlib
     - numpy

--- a/facets/facets.py
+++ b/facets/facets.py
@@ -75,6 +75,8 @@ _BT = ['bottom', 'top']
 
 
 class CbarShortSidePadMixin(object):
+    """Methods to redraw colorbar Axes created in AxesGrid, allowing for 
+    customization of their length."""
     def resize_colorbar(self, cax):
         """Add a short-side pad to a given AxesGrid colorbar"""
         locator = cax.get_axes_locator()
@@ -111,8 +113,15 @@ class CbarShortSidePadMixin(object):
 
 
 class ShareAxesMixin(object):
+    """Methods for redrawing axes created by an AxesGrid object
+
+    Enables axes sharing in the style of plt.subplots and for the passing of
+    custom keyword arguments to the Axes constructor (e.g. this allows one to
+    pass a cartopy projection).
+    """
     @property
     def sharex(self):
+        """The sharex mode of the object."""
         if isinstance(self._sharex, bool):
             result = 'all' if self._sharex else 'none'
         else:
@@ -121,6 +130,7 @@ class ShareAxesMixin(object):
 
     @property
     def sharey(self):
+        """The sharey mode of the object"""
         if isinstance(self._sharey, bool):
             result = 'all' if self._sharey else 'none'
         else:
@@ -128,6 +138,8 @@ class ShareAxesMixin(object):
         return result
 
     def redraw_ax(self, ax, sharex=None, sharey=None, axes_kwargs={}):
+        """Redraw an Axes object created in AxesGrid with additional sharing
+        and keyword arguments."""
         locator = ax.get_axes_locator()
         position = locator(ax, None)
         ax.set_visible(False)
@@ -135,6 +147,8 @@ class ShareAxesMixin(object):
                                  **axes_kwargs)
 
     def redraw_axes(self):
+        """Redraw all Axes objects created in AxesGrid with appropriate shared
+        axes depending on the sharing modes."""
         col_ref_axes = [None] * self.cols
         row_ref_axes = [None] * self.rows
         all_ref = None
@@ -170,6 +184,7 @@ class ShareAxesMixin(object):
         return axes
 
     def set_ticklabel_visibility(self):
+        """Make inner Axes tick labels of shared Axes invisible."""
         axes = np.reshape(self.axes, (self.rows, self.cols))
         if self.sharex in ['col', 'all']:
             for ax in axes[:-1, :].flatten():

--- a/facets/facets.py
+++ b/facets/facets.py
@@ -128,7 +128,6 @@ class ShareAxesMixin(object):
         for ax, (row, col) in zip(self.grid.axes_all, rows_cols):
             if self.sharex == 'all':
                 sharex = all_ref
-                print(sharex)
             elif self.sharex == 'col':
                 sharex = col_ref_axes[col]
             elif self.sharex == 'row':

--- a/facets/facets.py
+++ b/facets/facets.py
@@ -232,16 +232,18 @@ class WidthConstrainedAxesGrid(CbarShortSidePadMixin, ShareAxesMixin):
         # and the colorbar mode is 'single', AxesGrid adds an extra
         # axes pad to the colorbar padding; we correct this manually here.
         if self.cbar_location == 'bottom' and self.cbar_mode == 'single':
-            self.cbar_pad = self.cbar_pad - self.axes_pad[1]
+            axes_grid_cbar_pad = self.cbar_pad - self.axes_pad[1]
         elif self.cbar_location == 'left' and self.cbar_mode == 'single':
-            self.cbar_pad = self.cbar_pad - self.axes_pad[0]
+            axes_grid_cbar_pad = self.cbar_pad - self.axes_pad[0]
+        else:
+            axes_grid_cbar_pad = self.cbar_pad
 
         self.cbar_short_side_pad = cbar_short_side_pad
 
         self.fig = plt.figure()
         self.grid = AxesGrid(
             self.fig, self.rect(), nrows_ncols=(self.rows, self.cols),
-            cbar_size=self.cbar_size, cbar_pad=self.cbar_pad,
+            cbar_size=self.cbar_size, cbar_pad=axes_grid_cbar_pad,
             axes_pad=self.axes_pad, cbar_mode=self.cbar_mode,
             cbar_location=self.cbar_location, aspect=False
         )

--- a/facets/facets.py
+++ b/facets/facets.py
@@ -160,13 +160,11 @@ class ShareAxesMixin(object):
             for ax in axes[:-1, :].flatten():
                 ax.xaxis.set_tick_params(which='both', labelbottom=False,
                                          labeltop=False)
-                ax.xaxis.offsetText.set_visible(False)
 
         if self.sharey in ['row', 'all']:
             for ax in axes[:, 1:].flatten():
                 ax.yaxis.set_tick_params(which='both', labelbottom=False,
                                          labeltop=False)
-                ax.yaxis.offsetText.set_visible(False)
 
 
 class WidthConstrainedAxesGrid(CbarShortSidePadMixin, ShareAxesMixin):

--- a/facets/facets.py
+++ b/facets/facets.py
@@ -9,7 +9,7 @@ from mpl_toolkits.axes_grid1 import AxesGrid
 def facets(rows, cols, width=8., aspect=0.618, top_pad=0.25,
            bottom_pad=0.25, left_pad=0.25, right_pad=0.25, internal_pad=0.33,
            cbar_mode=None, cbar_short_side_pad=0.5, cbar_pad=0.5,
-           cbar_size=0.125, cbar_location='right', sharex=False, sharey=False,
+           cbar_size=0.125, cbar_location='right', sharex='all', sharey='all',
            axes_kwargs={}):
     """Create figure and tiled axes objects with precise attributes
 

--- a/facets/facets.py
+++ b/facets/facets.py
@@ -183,7 +183,7 @@ class ShareAxesMixin(object):
 
         return axes
 
-    def set_ticklabel_visibility(self):
+    def make_shared_ticklabels_invisible(self):
         """Make inner Axes tick labels of shared Axes invisible."""
         axes = np.reshape(self.axes, (self.rows, self.cols))
         if self.sharex in ['col', 'all']:
@@ -249,7 +249,7 @@ class WidthConstrainedAxesGrid(CbarShortSidePadMixin, ShareAxesMixin):
         )
         self.fig.set_size_inches(self.width, self.height)
         self.axes = self.redraw_axes()
-        self.set_ticklabel_visibility()
+        self.make_shared_ticklabels_invisible()
         self.caxes = self.resize_colorbars()
 
     @property

--- a/facets/facets.py
+++ b/facets/facets.py
@@ -45,9 +45,9 @@ def facets(rows, cols, width=8., aspect=0.618, top_pad=0.25,
         Width of the colorbar in inches
     cbar_location : {'top', 'bottom', 'left', 'right'}
         Side of the plot axes (or figure) for the colorbar
-    sharex : bool
+    sharex : bool or {'all', 'col', 'row', 'none'}
         Share x-axis limits, ticks, and tick labels
-    sharey : bool
+    sharey : bool or {'all', 'col', 'row', 'none'}
         Share y-axis limits, ticks, and tick labels
     axes_kwargs : dict
         Keyword arguments to pass to Axes constructor
@@ -111,6 +111,22 @@ class CbarShortSidePadMixin(object):
 
 
 class ShareAxesMixin(object):
+    @property
+    def sharex(self):
+        if isinstance(self._sharex, bool):
+            result = 'all' if self._sharex else 'none'
+        else:
+            result = self._sharex
+        return result
+
+    @property
+    def sharey(self):
+        if isinstance(self._sharey, bool):
+            result = 'all' if self._sharey else 'none'
+        else:
+            result = self._sharey
+        return result
+
     def redraw_ax(self, ax, sharex=None, sharey=None, axes_kwargs={}):
         locator = ax.get_axes_locator()
         position = locator(ax, None)
@@ -193,8 +209,8 @@ class WidthConstrainedAxesGrid(CbarShortSidePadMixin, ShareAxesMixin):
         self.cbar_pad = cbar_pad
         self.cbar_location = cbar_location
 
-        self.sharex = sharex
-        self.sharey = sharey
+        self._sharex = sharex
+        self._sharey = sharey
         self.axes_kwargs = axes_kwargs
 
         # For some reason when the colorbar is placed at the bottom or left

--- a/facets/tests/test_facets.py
+++ b/facets/tests/test_facets.py
@@ -104,6 +104,19 @@ def test_width_constrained_caxes_positions(grid):
         pytest.skip('Skipping colorbar positions test, because cbar_mode=None')
 
 
+def test_plot_aspect(grid):
+    fig = grid.fig
+    width, height = fig.get_size_inches()
+    for ax in grid.axes:
+        ax_bounds = ax.bbox.inverse_transformed(fig.transFigure).bounds
+        _, _, _plot_width, _plot_height = ax_bounds
+        plot_width = _plot_width * width
+        plot_height = _plot_height * height
+        expected = grid.aspect
+        result = plot_height / plot_width
+        np.testing.assert_allclose(result, expected)
+
+
 def check_width_constrained_axes_positions_none(grid):
     rows, cols = grid.rows, grid.cols
     width, height = grid.width, grid.height

--- a/facets/tests/test_facets.py
+++ b/facets/tests/test_facets.py
@@ -417,6 +417,7 @@ def test_share_axes_mixin(sharex, sharey):
     grid = shared_grid(sharex, sharey)
     assert_valid_x_sharing(grid, sharex)
     assert_valid_y_sharing(grid, sharey)
+    plt.close(grid.fig)
 
 
 def test_cartopy():
@@ -427,3 +428,4 @@ def test_cartopy():
     fig, axes = facets(2, 2, axes_kwargs={'projection': ccrs.PlateCarree()})
     for ax in axes:
         assert isinstance(ax, GeoAxes)
+    plt.close(fig)

--- a/facets/tests/test_facets.py
+++ b/facets/tests/test_facets.py
@@ -76,12 +76,6 @@ def grid(request):
     plt.close(obj.fig)
 
 
-def get_position(ax):
-    locator = ax.get_axes_locator()
-    position = locator(ax, None)
-    return position
-
-
 def get_tile_width(grid, left_pad=_LEFT_PAD, right_pad=_RIGHT_PAD):
     return (grid.width - left_pad - right_pad
             - (grid.cols - 1) * _INTERNAL_PAD) / grid.cols

--- a/facets/tests/test_facets.py
+++ b/facets/tests/test_facets.py
@@ -417,3 +417,13 @@ def test_share_axes_mixin(sharex, sharey):
     grid = shared_grid(sharex, sharey)
     assert_valid_x_sharing(grid, sharex)
     assert_valid_y_sharing(grid, sharey)
+
+
+def test_cartopy():
+    pytest.importorskip('cartopy')
+    import cartopy.crs as ccrs
+    from cartopy.mpl.geoaxes import GeoAxes
+
+    fig, axes = facets(2, 2, axes_kwargs={'projection': ccrs.PlateCarree()})
+    for ax in axes:
+        assert isinstance(ax, GeoAxes)

--- a/facets/tests/test_facets.py
+++ b/facets/tests/test_facets.py
@@ -290,3 +290,92 @@ def check_width_constrained_caxes_positions_each(grid):
             dy = (tile_height - 2. * _SHORT_SIDE_PAD) / height
             expected_bounds = [x0, y0, dx, dy]
             np.testing.assert_allclose(cax_bounds, expected_bounds)
+
+
+def shared_grid(sharex, sharey):
+    return WidthConstrainedAxesGrid(
+        2, 2, _WIDTH_CONSTRAINT, sharex=sharex, sharey=sharey,
+        cbar_mode='single')
+
+
+def assert_valid_x_sharing(shared_grid, sharex):
+    axes = np.reshape(shared_grid.axes, (shared_grid.rows, shared_grid.cols))
+    if sharex == 'all':
+        ax_ref = axes.flatten()[0]
+        for ax in axes.flatten():
+            assert ax.xaxis.major == ax_ref.xaxis.major
+            assert ax.xaxis.minor == ax_ref.xaxis.minor
+    elif sharex == 'row':
+        for row in axes:
+            ax_ref = row[0]
+            for ax in row:
+                assert ax.xaxis.major == ax_ref.xaxis.major
+                assert ax.xaxis.minor == ax_ref.xaxis.minor
+        for col in axes.T:
+            ax_ref = col[0]
+            for ax in col[1:]:
+                assert ax.xaxis.major != ax_ref.xaxis.major
+                assert ax.xaxis.minor != ax_ref.xaxis.minor
+    elif sharex == 'col':
+        for col in axes.T:
+            ax_ref = col[0]
+            for ax in col:
+                assert ax.xaxis.major == ax_ref.xaxis.major
+                assert ax.xaxis.minor == ax_ref.xaxis.minor
+        for row in axes:
+            ax_ref = row[0]
+            for ax in row[1:]:
+                assert ax.xaxis.major != ax_ref.xaxis.major
+                assert ax.xaxis.minor != ax_ref.xaxis.minor
+    elif sharex == 'none':
+        ax_ref = axes.flatten()[0]
+        for ax in axes.flatten()[1:]:
+            assert ax.xaxis.major != ax_ref.xaxis.major
+            assert ax.xaxis.minor != ax_ref.xaxis.minor        
+
+
+def assert_valid_y_sharing(shared_grid, sharey):
+    axes = np.reshape(shared_grid.axes, (shared_grid.rows, shared_grid.cols))
+    if sharey == 'all':
+        ax_ref = axes.flatten()[0]
+        for ax in axes.flatten():
+            assert ax.yaxis.major == ax_ref.yaxis.major
+            assert ax.yaxis.minor == ax_ref.yaxis.minor
+    elif sharey == 'row':
+        for row in axes:
+            ax_ref = row[0]
+            for ax in row:
+                assert ax.yaxis.major == ax_ref.yaxis.major
+                assert ax.yaxis.minor == ax_ref.yaxis.minor
+        for col in axes.T:
+            ax_ref = col[0]
+            for ax in col[1:]:
+                assert ax.yaxis.major != ax_ref.yaxis.major
+                assert ax.yaxis.minor != ax_ref.yaxis.minor
+    elif sharey == 'col':
+        for col in axes.T:
+            ax_ref = col[0]
+            for ax in col:
+                assert ax.yaxis.major == ax_ref.yaxis.major
+                assert ax.yaxis.minor == ax_ref.yaxis.minor
+        for row in axes:
+            ax_ref = row[0]
+            for ax in row[1:]:
+                assert ax.yaxis.major != ax_ref.yaxis.major
+                assert ax.yaxis.minor != ax_ref.yaxis.minor
+    elif sharey == 'none':
+        ax_ref = axes.flatten()[0]
+        for ax in axes.flatten()[1:]:
+            assert ax.yaxis.major != ax_ref.yaxis.major
+            assert ax.yaxis.minor != ax_ref.yaxis.minor
+
+
+_SHARE_OPTIONS = ['all', 'row', 'col', 'none']
+
+
+@pytest.mark.parametrize(
+    ('sharex', 'sharey'), product(_SHARE_OPTIONS, _SHARE_OPTIONS))
+def test_share_axes_mixin(sharex, sharey):
+    grid = shared_grid(sharex, sharey)
+    assert_valid_x_sharing(grid, sharex)
+    assert_valid_y_sharing(grid, sharey)

--- a/facets/tests/test_facets.py
+++ b/facets/tests/test_facets.py
@@ -114,10 +114,11 @@ def check_width_constrained_axes_positions_none(grid):
     rows, cols = grid.rows, grid.cols
     width, height = grid.width, grid.height
     tile_width, tile_height = get_tile_width(grid), get_tile_height(grid)
+    fig = grid.fig
 
     indexes = list(product(range(rows - 1, -1, -1), range(cols)))
     for ax, (row, col) in zip(grid.axes, indexes):
-        ax_bounds = get_position(ax).bounds
+        ax_bounds = ax.bbox.inverse_transformed(fig.transFigure).bounds
         x0 = (_LEFT_PAD + col * (_INTERNAL_PAD + tile_width)) / width
         y0 = (_BOTTOM_PAD + row * (_INTERNAL_PAD + tile_height)) / height
         dx = tile_width / width
@@ -130,6 +131,7 @@ def check_width_constrained_axes_positions_single(grid):
     rows, cols = grid.rows, grid.cols
     width, height = grid.width, grid.height
     cbar_location = grid.cbar_location
+    fig = grid.fig
 
     left_pad, right_pad = _LEFT_PAD, _RIGHT_PAD
     bottom_pad, top_pad = _BOTTOM_PAD, _TOP_PAD
@@ -148,7 +150,7 @@ def check_width_constrained_axes_positions_single(grid):
     indexes = list(product(range(rows - 1, -1, -1), range(cols)))
     axes = grid.axes
     for ax, (row, col) in zip(axes, indexes):
-        ax_bounds = get_position(ax).bounds
+        ax_bounds = ax.bbox.inverse_transformed(fig.transFigure).bounds
         x0 = (left_pad + col * (_INTERNAL_PAD + tile_width)) / width
         y0 = (bottom_pad + row * (_INTERNAL_PAD + tile_height)) / height
         dx = tile_width / width
@@ -193,12 +195,13 @@ def check_width_constrained_axes_positions_each(grid):
     width, height = grid.width, grid.height
     tile_width, tile_height = get_tile_width(grid), get_tile_height(grid)
     cbar_location = grid.cbar_location
+    fig = grid.fig
 
     indexes = list(product(range(rows - 1, -1, -1), range(cols)))
     axes = grid.axes
     if cbar_location == 'bottom':
         for ax, (row, col) in zip(axes, indexes):
-            ax_bounds = get_position(ax).bounds
+            ax_bounds = ax.bbox.inverse_transformed(fig.transFigure).bounds
             x0 = (_LEFT_PAD + col * (tile_width + _INTERNAL_PAD)) / width
             y0 = (_BOTTOM_PAD + _CBAR_THICKNESS + _LONG_SIDE_PAD +
                   row * (tile_height + _INTERNAL_PAD)) / height
@@ -208,7 +211,7 @@ def check_width_constrained_axes_positions_each(grid):
             np.testing.assert_allclose(ax_bounds, expected_bounds)
     elif cbar_location == 'top':
         for ax, (row, col) in zip(axes, indexes):
-            ax_bounds = get_position(ax).bounds
+            ax_bounds = ax.bbox.inverse_transformed(fig.transFigure).bounds
             x0 = (_LEFT_PAD + col * (_INTERNAL_PAD + tile_width)) / width
             y0 = (_BOTTOM_PAD + row * (_INTERNAL_PAD + tile_height)) / height
             dx = tile_width / width
@@ -217,7 +220,7 @@ def check_width_constrained_axes_positions_each(grid):
             np.testing.assert_allclose(ax_bounds, expected_bounds)
     elif cbar_location == 'right':
         for ax, (row, col) in zip(axes, indexes):
-            ax_bounds = get_position(ax).bounds
+            ax_bounds = ax.bbox.inverse_transformed(fig.transFigure).bounds
             x0 = (_LEFT_PAD + col * (_INTERNAL_PAD + tile_width)) / width
             y0 = (_BOTTOM_PAD + row * (_INTERNAL_PAD + tile_height)) / height
             dx = (tile_width - _CBAR_THICKNESS - _LONG_SIDE_PAD) / width
@@ -226,7 +229,7 @@ def check_width_constrained_axes_positions_each(grid):
             np.testing.assert_allclose(ax_bounds, expected_bounds)
     elif cbar_location == 'left':
         for ax, (row, col) in zip(axes, indexes):
-            ax_bounds = get_position(ax).bounds
+            ax_bounds = ax.bbox.inverse_transformed(fig.transFigure).bounds
             x0 = (_LEFT_PAD + _CBAR_THICKNESS + _LONG_SIDE_PAD +
                   col * (_INTERNAL_PAD + tile_width)) / width
             y0 = (_BOTTOM_PAD + row * (_INTERNAL_PAD + tile_height)) / height

--- a/facets/tests/test_facets.py
+++ b/facets/tests/test_facets.py
@@ -292,13 +292,37 @@ def shared_grid(sharex, sharey):
         cbar_mode='single')
 
 
+def assert_visible_xticklabels(ax):
+    assert ax.xaxis._get_tick(ax.xaxis.major).label1On
+    assert ax.xaxis._get_tick(ax.xaxis.minor).label1On
+
+
+def assert_invisible_xticklabels(ax):
+    assert not ax.xaxis._get_tick(ax.xaxis.major).label1On
+    assert not ax.xaxis._get_tick(ax.xaxis.minor).label1On
+
+
+def assert_visible_yticklabels(ax):
+    assert ax.yaxis._get_tick(ax.yaxis.major).label1On
+    assert ax.yaxis._get_tick(ax.yaxis.minor).label1On
+
+
+def assert_invisible_yticklabels(ax):
+    assert not ax.yaxis._get_tick(ax.yaxis.major).label1On
+    assert not ax.yaxis._get_tick(ax.yaxis.minor).label1On
+
+
 def assert_valid_x_sharing(shared_grid, sharex):
     axes = np.reshape(shared_grid.axes, (shared_grid.rows, shared_grid.cols))
-    if sharex == 'all':
+    if sharex in ['all', True]:
         ax_ref = axes.flatten()[0]
         for ax in axes.flatten():
             assert ax.xaxis.major == ax_ref.xaxis.major
             assert ax.xaxis.minor == ax_ref.xaxis.minor
+        for ax in axes[:-1, :].flatten():
+            assert_invisible_xticklabels(ax)
+        for ax in axes[-1, :].flatten():
+            assert_visible_xticklabels(ax)
     elif sharex == 'row':
         for row in axes:
             ax_ref = row[0]
@@ -310,6 +334,8 @@ def assert_valid_x_sharing(shared_grid, sharex):
             for ax in col[1:]:
                 assert ax.xaxis.major != ax_ref.xaxis.major
                 assert ax.xaxis.minor != ax_ref.xaxis.minor
+        for ax in axes.flatten():
+            assert_visible_xticklabels(ax)
     elif sharex == 'col':
         for col in axes.T:
             ax_ref = col[0]
@@ -321,20 +347,30 @@ def assert_valid_x_sharing(shared_grid, sharex):
             for ax in row[1:]:
                 assert ax.xaxis.major != ax_ref.xaxis.major
                 assert ax.xaxis.minor != ax_ref.xaxis.minor
-    elif sharex == 'none':
+        for ax in axes[:-1, :].flatten():
+            assert_invisible_xticklabels(ax)
+        for ax in axes[-1, :].flatten():
+            assert_visible_xticklabels(ax)
+    elif sharex in ['none', False]:
         ax_ref = axes.flatten()[0]
         for ax in axes.flatten()[1:]:
             assert ax.xaxis.major != ax_ref.xaxis.major
-            assert ax.xaxis.minor != ax_ref.xaxis.minor        
+            assert ax.xaxis.minor != ax_ref.xaxis.minor
+        for ax in axes.flatten():
+            assert_visible_xticklabels(ax)
 
 
 def assert_valid_y_sharing(shared_grid, sharey):
     axes = np.reshape(shared_grid.axes, (shared_grid.rows, shared_grid.cols))
-    if sharey == 'all':
+    if sharey in ['all', True]:
         ax_ref = axes.flatten()[0]
         for ax in axes.flatten():
             assert ax.yaxis.major == ax_ref.yaxis.major
             assert ax.yaxis.minor == ax_ref.yaxis.minor
+        for ax in axes[:, 1:].flatten():
+            assert_invisible_yticklabels(ax)
+        for ax in axes[:, 0].flatten():
+            assert_visible_yticklabels(ax)
     elif sharey == 'row':
         for row in axes:
             ax_ref = row[0]
@@ -346,6 +382,10 @@ def assert_valid_y_sharing(shared_grid, sharey):
             for ax in col[1:]:
                 assert ax.yaxis.major != ax_ref.yaxis.major
                 assert ax.yaxis.minor != ax_ref.yaxis.minor
+        for ax in axes[:, 1:].flatten():
+            assert_invisible_yticklabels(ax)
+        for ax in axes[:, 0].flatten():
+            assert_visible_yticklabels(ax)
     elif sharey == 'col':
         for col in axes.T:
             ax_ref = col[0]
@@ -357,14 +397,18 @@ def assert_valid_y_sharing(shared_grid, sharey):
             for ax in row[1:]:
                 assert ax.yaxis.major != ax_ref.yaxis.major
                 assert ax.yaxis.minor != ax_ref.yaxis.minor
-    elif sharey == 'none':
+        for ax in axes.flatten():
+            assert_visible_yticklabels(ax)
+    elif sharey in ['none', False]:
         ax_ref = axes.flatten()[0]
         for ax in axes.flatten()[1:]:
             assert ax.yaxis.major != ax_ref.yaxis.major
             assert ax.yaxis.minor != ax_ref.yaxis.minor
+        for ax in axes.flatten():
+            assert_visible_yticklabels(ax)
 
 
-_SHARE_OPTIONS = ['all', 'row', 'col', 'none']
+_SHARE_OPTIONS = ['all', 'row', 'col', 'none', True, False]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
~~This still needs tests and could probably be cleaned up some.  Pending that, what's here already addresses #9 and #12.~~

Closes #9; closes #12; closes #19.
  