### PR TITLE
Temporarily pin matplotlib to version 2.2.3

### DIFF
--- a/ci/environment-py36.yml
+++ b/ci/environment-py36.yml
@@ -5,7 +5,7 @@ dependencies:
     - python=3.6
     - cartopy
     - jupyter
-    - matplotlib
+    - matplotlib=2.2.3
     - numpy
     - pytest
     - pip:


### PR DESCRIPTION
Cartopy will soon support matplotlib version 3.0, but until then we'll pin to an earlier matplotlib version so that the tests pass.  

This should fix the following error on Travis:
```
E                   AttributeError                            Traceback (most recent call last)
E                   <ipython-input-6-e02db6cc727a> in <module>
E                        13 
E                        14 for ax in axes:
E                   ---> 15     c = ax.pcolormesh(x, y, z, vmin=-1., vmax=1., cmap='RdBu', transform=ccrs.PlateCarree())
E                        16     ax.set_global()
E                        17 
E                   
E                   ~/miniconda/envs/test_env/lib/python3.6/site-packages/cartopy/mpl/geoaxes.py in pcolormesh(self, *args, **kwargs)
E                      1449                              ' consider using PlateCarree/RotatedPole.')
E                      1450         kwargs.setdefault('transform', t)
E                   -> 1451         result = self._pcolormesh_patched(*args, **kwargs)
E                      1452         self.autoscale_view()
E                      1453         return result
E                   
E                   ~/miniconda/envs/test_env/lib/python3.6/site-packages/cartopy/mpl/geoaxes.py in _pcolormesh_patched(self, *args, **kwargs)
E                      1467         import matplotlib.collections as mcoll
E                      1468 
E                   -> 1469         if not self._hold:
E                      1470             self.cla()
E                      1471 
E                   
E                   AttributeError: 'GeoAxes' object has no attribute '_hold'
E                   AttributeError: 'GeoAxes' object has no attribute '_hold'
```