### PR TITLE
Enable a tuple-specification of the internal_pad

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ the figure, are explained below:
 - E: `cbar_short_side_pad` controls the spacing between the edges of the
   colorbar and the edges of the axes in inches
 - F: `internal_pad` controls the spacing between the non-colorbar axes in
-  inches.  It can either be a float (and specify the horizontal and vertical
+  inches.  It can either be a number (and specify the horizontal and vertical
   pad at the same time) or it can be a length-two sequence (and specify both
   the horizontal and vertical pads, respectively).
 - G: `cbar_pad` controls the spacing (in inches) between the edge of the

--- a/README.md
+++ b/README.md
@@ -84,8 +84,10 @@ the figure, are explained below:
   the figure in inches
 - E: `cbar_short_side_pad` controls the spacing between the edges of the
   colorbar and the edges of the axes in inches
-- F: `internal_pad` controls the spacing between the non-colorbar axes (for now
-  this is both the vertical and horizontal spacing) in inches
+- F: `internal_pad` controls the spacing between the non-colorbar axes in
+  inches.  It can either be a float (and specify the horizontal and vertical
+  pad at the same time) or it can be a length-two sequence (and specify both
+  the horizontal and vertical pads, respectively).
 - G: `cbar_pad` controls the spacing (in inches) between the edge of the
   non-colorbar axes and the colorbar axes.
 

--- a/facets/facets.py
+++ b/facets/facets.py
@@ -33,9 +33,9 @@ def facets(rows, cols, width=8., aspect=0.618, top_pad=0.25,
         Spacing (in inches) between right of figure and axes
     internal_pad : float or tuple
         Spacing in between panels in both the horizontal and vertical
-        directions (in inches); if an individual float, the spacing is the same
-        in the horizontal and vertical; if a tuple is specified, the left value
-        is the horizontal pad, and the right value is the vertical pad.
+        directions (in inches); if an individual number, the spacing is the
+        same in the horizontal and vertical; if a tuple is specified, the left
+        value is the horizontal pad, and the right value is the vertical pad.
     cbar_mode : {None, 'single', 'edge', 'each'}
         Mode for adding colorbar(s) to figure
     cbar_short_side_pad : float
@@ -59,7 +59,7 @@ def facets(rows, cols, width=8., aspect=0.618, top_pad=0.25,
     -------
     fig, axes, caxes (if caxes requested)
     """
-    if isinstance(internal_pad, float):
+    if isinstance(internal_pad, (float, int)):
         internal_pad = (internal_pad, internal_pad)
     if len(internal_pad) != 2:
         raise ValueError('Invalid internal pad provided; it must either be a '

--- a/facets/facets.py
+++ b/facets/facets.py
@@ -31,8 +31,11 @@ def facets(rows, cols, width=8., aspect=0.618, top_pad=0.25,
         Spacing (in inches) between left of figure and axes
     right_pad : float
         Spacing (in inches) between right of figure and axes
-    internal_pad : float
-        Spacing in between tiles (in inches)
+    internal_pad : float or tuple
+        Spacing in between panels in both the horizontal and vertical
+        directions (in inches); if an individual float, the spacing is the same
+        in the horizontal and vertical; if a tuple is specified, the left value
+        is the horizontal pad, and the right value is the vertical pad.
     cbar_mode : {None, 'single', 'edge', 'each'}
         Mode for adding colorbar(s) to figure
     cbar_short_side_pad : float
@@ -56,6 +59,13 @@ def facets(rows, cols, width=8., aspect=0.618, top_pad=0.25,
     -------
     fig, axes, caxes (if caxes requested)
     """
+    if isinstance(internal_pad, float):
+        internal_pad = (internal_pad, internal_pad)
+    if len(internal_pad) != 2:
+        raise ValueError('Invalid internal pad provided; it must either be a '
+                         'float or a sequence of two values.  Got '
+                         '{}'.format(internal_pad))
+
     grid = WidthConstrainedAxesGrid(
         rows, cols, width=width, aspect=aspect, top_pad=top_pad,
         bottom_pad=bottom_pad, left_pad=left_pad, right_pad=right_pad,
@@ -75,7 +85,7 @@ _BT = ['bottom', 'top']
 
 
 class CbarShortSidePadMixin(object):
-    """Methods to redraw colorbar Axes created in AxesGrid, allowing for 
+    """Methods to redraw colorbar Axes created in AxesGrid, allowing for
     customization of their length."""
     def resize_colorbar(self, cax):
         """Add a short-side pad to a given AxesGrid colorbar"""
@@ -206,7 +216,7 @@ class WidthConstrainedAxesGrid(CbarShortSidePadMixin, ShareAxesMixin):
     """
     def __init__(self, rows, cols, width, top_pad=0., bottom_pad=0.,
                  left_pad=0., right_pad=0., cbar_size=0.125,
-                 cbar_pad=0.125, axes_pad=0.2, cbar_mode=None,
+                 cbar_pad=0.125, axes_pad=(0.2, 0.2), cbar_mode=None,
                  cbar_location='bottom', aspect=0.5, cbar_short_side_pad=0.,
                  sharex=False, sharey=False, axes_kwargs={}):
         self.rows = rows
@@ -214,8 +224,7 @@ class WidthConstrainedAxesGrid(CbarShortSidePadMixin, ShareAxesMixin):
         self.width = width
         self.aspect = aspect
 
-        # We'll put off supporting a tuple axes_pad until later
-        self.axes_pad = (axes_pad, axes_pad)
+        self.axes_pad = axes_pad
 
         self.top_pad = top_pad
         self.bottom_pad = bottom_pad

--- a/facets/tests/test_facets.py
+++ b/facets/tests/test_facets.py
@@ -13,7 +13,9 @@ plt.switch_backend('agg')
 
 
 _TOP_PAD = _BOTTOM_PAD = _LEFT_PAD = _RIGHT_PAD = 0.25
-_INTERNAL_PAD = 0.25
+_HORIZONTAL_INTERNAL_PAD = 0.25
+_VERTICAL_INTERNAL_PAD = 0.5
+_INTERNAL_PAD = (_HORIZONTAL_INTERNAL_PAD, _VERTICAL_INTERNAL_PAD)
 _ASPECT = 0.5
 _WIDTH_CONSTRAINT = 8.
 _SHORT_SIDE_PAD = 0.25
@@ -78,12 +80,12 @@ def grid(request):
 
 def get_tile_width(grid, left_pad=_LEFT_PAD, right_pad=_RIGHT_PAD):
     return (grid.width - left_pad - right_pad
-            - (grid.cols - 1) * _INTERNAL_PAD) / grid.cols
+            - (grid.cols - 1) * _HORIZONTAL_INTERNAL_PAD) / grid.cols
 
 
 def get_tile_height(grid, bottom_pad=_BOTTOM_PAD, top_pad=_TOP_PAD):
     return (grid.height - bottom_pad - top_pad -
-            (grid.rows - 1) * _INTERNAL_PAD) / grid.rows
+            (grid.rows - 1) * _VERTICAL_INTERNAL_PAD) / grid.rows
 
 
 def test_width_constrained_axes_positions(grid):
@@ -130,8 +132,10 @@ def check_width_constrained_axes_positions_none(grid):
     indexes = list(product(range(rows - 1, -1, -1), range(cols)))
     for ax, (row, col) in zip(grid.axes, indexes):
         ax_bounds = ax.bbox.inverse_transformed(fig.transFigure).bounds
-        x0 = (_LEFT_PAD + col * (_INTERNAL_PAD + tile_width)) / width
-        y0 = (_BOTTOM_PAD + row * (_INTERNAL_PAD + tile_height)) / height
+        x0 = (_LEFT_PAD + col * (_HORIZONTAL_INTERNAL_PAD
+                                 + tile_width)) / width
+        y0 = (_BOTTOM_PAD + row * (_VERTICAL_INTERNAL_PAD
+                                   + tile_height)) / height
         dx = tile_width / width
         dy = tile_height / height
         expected_bounds = [x0, y0, dx, dy]
@@ -162,8 +166,9 @@ def check_width_constrained_axes_positions_single(grid):
     axes = grid.axes
     for ax, (row, col) in zip(axes, indexes):
         ax_bounds = ax.bbox.inverse_transformed(fig.transFigure).bounds
-        x0 = (left_pad + col * (_INTERNAL_PAD + tile_width)) / width
-        y0 = (bottom_pad + row * (_INTERNAL_PAD + tile_height)) / height
+        x0 = (left_pad + col * (_HORIZONTAL_INTERNAL_PAD + tile_width)) / width
+        y0 = (bottom_pad + row * (_VERTICAL_INTERNAL_PAD
+                                  + tile_height)) / height
         dx = tile_width / width
         dy = tile_height / height
         expected_bounds = [x0, y0, dx, dy]
@@ -213,9 +218,11 @@ def check_width_constrained_axes_positions_each(grid):
     if cbar_location == 'bottom':
         for ax, (row, col) in zip(axes, indexes):
             ax_bounds = ax.bbox.inverse_transformed(fig.transFigure).bounds
-            x0 = (_LEFT_PAD + col * (tile_width + _INTERNAL_PAD)) / width
+            x0 = (_LEFT_PAD + col * (tile_width +
+                                     _HORIZONTAL_INTERNAL_PAD)) / width
             y0 = (_BOTTOM_PAD + _CBAR_THICKNESS + _LONG_SIDE_PAD +
-                  row * (tile_height + _INTERNAL_PAD)) / height
+                  row * (tile_height +
+                         _VERTICAL_INTERNAL_PAD)) / height
             dx = tile_width / width
             dy = (tile_height - _CBAR_THICKNESS - _LONG_SIDE_PAD) / height
             expected_bounds = [x0, y0, dx, dy]
@@ -223,8 +230,10 @@ def check_width_constrained_axes_positions_each(grid):
     elif cbar_location == 'top':
         for ax, (row, col) in zip(axes, indexes):
             ax_bounds = ax.bbox.inverse_transformed(fig.transFigure).bounds
-            x0 = (_LEFT_PAD + col * (_INTERNAL_PAD + tile_width)) / width
-            y0 = (_BOTTOM_PAD + row * (_INTERNAL_PAD + tile_height)) / height
+            x0 = (_LEFT_PAD + col * (_HORIZONTAL_INTERNAL_PAD
+                                     + tile_width)) / width
+            y0 = (_BOTTOM_PAD + row * (_VERTICAL_INTERNAL_PAD
+                                       + tile_height)) / height
             dx = tile_width / width
             dy = (tile_height - _CBAR_THICKNESS - _LONG_SIDE_PAD) / height
             expected_bounds = [x0, y0, dx, dy]
@@ -232,8 +241,10 @@ def check_width_constrained_axes_positions_each(grid):
     elif cbar_location == 'right':
         for ax, (row, col) in zip(axes, indexes):
             ax_bounds = ax.bbox.inverse_transformed(fig.transFigure).bounds
-            x0 = (_LEFT_PAD + col * (_INTERNAL_PAD + tile_width)) / width
-            y0 = (_BOTTOM_PAD + row * (_INTERNAL_PAD + tile_height)) / height
+            x0 = (_LEFT_PAD + col * (_HORIZONTAL_INTERNAL_PAD +
+                                     tile_width)) / width
+            y0 = (_BOTTOM_PAD + row * (_VERTICAL_INTERNAL_PAD +
+                                       tile_height)) / height
             dx = (tile_width - _CBAR_THICKNESS - _LONG_SIDE_PAD) / width
             dy = tile_height / height
             expected_bounds = [x0, y0, dx, dy]
@@ -242,8 +253,9 @@ def check_width_constrained_axes_positions_each(grid):
         for ax, (row, col) in zip(axes, indexes):
             ax_bounds = ax.bbox.inverse_transformed(fig.transFigure).bounds
             x0 = (_LEFT_PAD + _CBAR_THICKNESS + _LONG_SIDE_PAD +
-                  col * (_INTERNAL_PAD + tile_width)) / width
-            y0 = (_BOTTOM_PAD + row * (_INTERNAL_PAD + tile_height)) / height
+                  col * (_HORIZONTAL_INTERNAL_PAD + tile_width)) / width
+            y0 = (_BOTTOM_PAD + row * (_VERTICAL_INTERNAL_PAD +
+                                       tile_height)) / height
             dx = (tile_width - _CBAR_THICKNESS - _LONG_SIDE_PAD) / width
             dy = tile_height / height
             expected_bounds = [x0, y0, dx, dy]
@@ -262,9 +274,10 @@ def check_width_constrained_caxes_positions_each(grid):
     if cbar_location == 'bottom':
         for cax, (row, col) in zip(caxes, indexes):
             cax_bounds = cax.bbox.inverse_transformed(fig.transFigure).bounds
-            x0 = (_LEFT_PAD + col * (_INTERNAL_PAD + tile_width) +
+            x0 = (_LEFT_PAD + col * (_HORIZONTAL_INTERNAL_PAD + tile_width) +
                   _SHORT_SIDE_PAD) / width
-            y0 = (_BOTTOM_PAD + row * (_INTERNAL_PAD + tile_height)) / height
+            y0 = (_BOTTOM_PAD + row * (_VERTICAL_INTERNAL_PAD +
+                                       tile_height)) / height
             dx = (tile_width - 2. * _SHORT_SIDE_PAD) / width
             dy = _CBAR_THICKNESS / height
             expected_bounds = [x0, y0, dx, dy]
@@ -272,9 +285,9 @@ def check_width_constrained_caxes_positions_each(grid):
     elif cbar_location == 'top':
         for cax, (row, col) in zip(caxes, indexes):
             cax_bounds = cax.bbox.inverse_transformed(fig.transFigure).bounds
-            x0 = (_LEFT_PAD + col * (_INTERNAL_PAD + tile_width) +
+            x0 = (_LEFT_PAD + col * (_HORIZONTAL_INTERNAL_PAD + tile_width) +
                   _SHORT_SIDE_PAD) / width
-            y0 = (_BOTTOM_PAD + row * (_INTERNAL_PAD + tile_height) +
+            y0 = (_BOTTOM_PAD + row * (_VERTICAL_INTERNAL_PAD + tile_height) +
                   tile_height - _CBAR_THICKNESS) / height
             dx = (tile_width - 2. * _SHORT_SIDE_PAD) / width
             dy = _CBAR_THICKNESS / height
@@ -283,9 +296,10 @@ def check_width_constrained_caxes_positions_each(grid):
     elif cbar_location == 'right':
         for cax, (row, col) in zip(caxes, indexes):
             cax_bounds = cax.bbox.inverse_transformed(fig.transFigure).bounds
-            x0 = (_LEFT_PAD + col * (_INTERNAL_PAD + tile_width) + tile_width -
+            x0 = (_LEFT_PAD + col * (_HORIZONTAL_INTERNAL_PAD +
+                                     tile_width) + tile_width -
                   _CBAR_THICKNESS) / width
-            y0 = (_BOTTOM_PAD + row * (_INTERNAL_PAD + tile_height) +
+            y0 = (_BOTTOM_PAD + row * (_VERTICAL_INTERNAL_PAD + tile_height) +
                   _SHORT_SIDE_PAD) / height
             dx = _CBAR_THICKNESS / width
             dy = (tile_height - 2. * _SHORT_SIDE_PAD) / height
@@ -294,8 +308,9 @@ def check_width_constrained_caxes_positions_each(grid):
     elif cbar_location == 'left':
         for cax, (row, col) in zip(caxes, indexes):
             cax_bounds = cax.bbox.inverse_transformed(fig.transFigure).bounds
-            x0 = (_LEFT_PAD + col * (_INTERNAL_PAD + tile_width)) / width
-            y0 = (_BOTTOM_PAD + row * (_INTERNAL_PAD + tile_height) +
+            x0 = (_LEFT_PAD + col * (_HORIZONTAL_INTERNAL_PAD
+                                     + tile_width)) / width
+            y0 = (_BOTTOM_PAD + row * (_VERTICAL_INTERNAL_PAD + tile_height) +
                   _SHORT_SIDE_PAD) / height
             dx = _CBAR_THICKNESS / width
             dy = (tile_height - 2. * _SHORT_SIDE_PAD) / height
@@ -319,7 +334,7 @@ def check_width_constrained_caxes_positions_edge(grid):
     if cbar_location == 'bottom':
         for col, cax in zip(range(cols), caxes):
             cax_bounds = cax.bbox.inverse_transformed(fig.transFigure).bounds
-            x0 = (_LEFT_PAD + col * (_INTERNAL_PAD + tile_width) +
+            x0 = (_LEFT_PAD + col * (_HORIZONTAL_INTERNAL_PAD + tile_width) +
                   _SHORT_SIDE_PAD) / width
             y0 = _BOTTOM_PAD / height
             dx = (tile_width - 2. * _SHORT_SIDE_PAD) / width
@@ -329,7 +344,7 @@ def check_width_constrained_caxes_positions_edge(grid):
     elif cbar_location == 'top':
         for col, cax in zip(range(cols), caxes):
             cax_bounds = cax.bbox.inverse_transformed(fig.transFigure).bounds
-            x0 = (_LEFT_PAD + col * (_INTERNAL_PAD + tile_width) +
+            x0 = (_LEFT_PAD + col * (_HORIZONTAL_INTERNAL_PAD + tile_width) +
                   _SHORT_SIDE_PAD) / width
             y0 = (height - _CBAR_THICKNESS - _TOP_PAD) / height
             dx = (tile_width - 2. * _SHORT_SIDE_PAD) / width
@@ -340,7 +355,7 @@ def check_width_constrained_caxes_positions_edge(grid):
         for row, cax in zip(range(rows - 1, -1, -1), caxes):
             cax_bounds = cax.bbox.inverse_transformed(fig.transFigure).bounds
             x0 = (width - _CBAR_THICKNESS - _RIGHT_PAD) / width
-            y0 = (_BOTTOM_PAD + row * (_INTERNAL_PAD + tile_height) +
+            y0 = (_BOTTOM_PAD + row * (_VERTICAL_INTERNAL_PAD + tile_height) +
                   _SHORT_SIDE_PAD) / height
             dx = _CBAR_THICKNESS / width
             dy = (tile_height - 2. * _SHORT_SIDE_PAD) / height
@@ -350,14 +365,14 @@ def check_width_constrained_caxes_positions_edge(grid):
         for row, cax in zip(range(rows - 1, -1, -1), caxes):
             cax_bounds = cax.bbox.inverse_transformed(fig.transFigure).bounds
             x0 = _LEFT_PAD / width
-            y0 = (_BOTTOM_PAD + row * (_INTERNAL_PAD + tile_height) +
+            y0 = (_BOTTOM_PAD + row * (_VERTICAL_INTERNAL_PAD + tile_height) +
                   _SHORT_SIDE_PAD) / height
             dx = _CBAR_THICKNESS / width
             dy = (tile_height - 2. * _SHORT_SIDE_PAD) / height
             expected_bounds = [x0, y0, dx, dy]
             np.testing.assert_allclose(cax_bounds, expected_bounds)
-    
-            
+
+
 def shared_grid(sharex, sharey):
     return WidthConstrainedAxesGrid(
         2, 2, _WIDTH_CONSTRAINT, sharex=sharex, sharey=sharey,

--- a/facets/tests/test_facets.py
+++ b/facets/tests/test_facets.py
@@ -47,6 +47,11 @@ def test_facets_cbar_mode_invalid():
         facets(1, 2, cbar_mode='invalid')
 
 
+def test_facets_invalid_internal_pad():
+    with pytest.raises(ValueError):
+        facets(1, 2, internal_pad=(1, 2, 3))
+
+
 _LAYOUTS = [(1, 1), (1, 2), (2, 1), (2, 2), (5, 3)]
 _CBAR_MODES = [None, 'single', 'each', 'edge']
 _CBAR_LOCATIONS = ['bottom', 'right', 'top', 'left']


### PR DESCRIPTION
Closes #8

This allows for the separate specification of the horizontal and vertical padding between panels (it is no longer strictly specified to be the same).