### PR TITLE
Add ability to create height-and-aspect or height-and-width constrained figures

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ faceted
 
 [![Build Status](https://travis-ci.org/spencerkclark/faceted.svg?branch=master)](https://travis-ci.org/spencerkclark/faceted)[![Coverage Status](https://coveralls.io/repos/github/spencerkclark/faceted/badge.svg?branch=master)](https://coveralls.io/github/spencerkclark/faceted?branch=master)[![Documentation Status](https://readthedocs.org/projects/faceted/badge/?version=latest)](https://faceted.readthedocs.io/en/latest/?badge=latest)
 
-Figures with precise control over overall width, plot aspect ratio,
-between-plot spacing, and colorbar dimensions.
+Figures with precise control over overall width, overall height,
+plot aspect ratio, between-plot spacing, and colorbar dimensions.
 
 Description
 -----------

--- a/ci/environment-py36.yml
+++ b/ci/environment-py36.yml
@@ -8,6 +8,7 @@ dependencies:
     - matplotlib
     - numpy
     - pytest
+    - scipy
     - pip:
       - coveralls
       - pytest-cov

--- a/ci/environment-py36.yml
+++ b/ci/environment-py36.yml
@@ -7,6 +7,7 @@ dependencies:
     - jupyter
     - matplotlib
     - numpy
+    - pip
     - pytest
     - scipy
     - pip:

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -9,6 +9,7 @@ dependencies:
     - nc-time-axis
     - numpy
     - pytest
+    - scipy
     - ipython=7.2.0
     - cftime=1.0.3.4
     - sphinx=1.8.2

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -3,7 +3,7 @@ channels:
     - conda-forge
 dependencies:
     - python=3.6
-    - cartopy=0.17.0
+    - cartopy
     - jupyter
     - matplotlib
     - nc-time-axis

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -8,6 +8,7 @@ dependencies:
     - matplotlib
     - nc-time-axis
     - numpy
+    - pip
     - pytest
     - scipy
     - ipython=7.2.0

--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -91,8 +91,101 @@ from the time mean at each location in the lower row instead.
         ax.tick_params(axis='x', labelrotation=45)
         
     @savefig example_tair_share_axes.png
-    fig.show()    
+    fig.show()
+
+Other kinds of constraints
+--------------------------
+
+:py:meth:`faceted.faceted` supports multiple kinds of constrained figures.  We simply need
+to provide exactly two of the ``width``, ``height``, and ``aspect`` arguments and :py:meth:`faceted.faceted`
+does the rest.
+
+Width-and-aspect constrained figure
+###################################
+
+This is what we've shown already, but for completeness we'll repeat the example again here.
+
+.. ipython:: python
+    :okwarning:
+
+    import matplotlib.pyplot as plt
+    import xarray as xr
+    from matplotlib import ticker
+    from faceted import faceted
+
+    tick_locator = ticker.MaxNLocator(nbins=3)
     
+    ds = xr.tutorial.load_dataset('rasm').isel(x=slice(30, 37), y=-1,
+                                               time=slice(0, 11))
+    temp = ds.Tair
+    
+    fig, axes = faceted(2, 3, width=8, aspect=0.618)
+    for i, ax in enumerate(axes):
+        temp.isel(x=i).plot(ax=ax, marker='o', ls='none')
+        ax.set_title('{:0.2f}'.format(temp.xc.isel(x=i).item()))
+        ax.set_xlabel('Time')
+        ax.set_ylabel('Temperature [C]')
+        ax.tick_params(axis='x', labelrotation=45)
+
+    @savefig example_tair_base.png
+    fig.show()
+
+Height-and-aspect constrained figure
+####################################
+
+.. ipython:: python
+    :okwarning:
+
+    import matplotlib.pyplot as plt
+    import xarray as xr
+    from matplotlib import ticker
+    from faceted import faceted
+
+    tick_locator = ticker.MaxNLocator(nbins=3)
+    
+    ds = xr.tutorial.load_dataset('rasm').isel(x=slice(30, 37), y=-1,
+                                               time=slice(0, 11))
+    temp = ds.Tair
+    
+    fig, axes = faceted(2, 3, height=8., aspect=0.618)
+    for i, ax in enumerate(axes):
+        temp.isel(x=i).plot(ax=ax, marker='o', ls='none')
+        ax.set_title('{:0.2f}'.format(temp.xc.isel(x=i).item()))
+        ax.set_xlabel('Time')
+        ax.set_ylabel('Temperature [C]')
+        ax.tick_params(axis='x', labelrotation=45)
+
+    @savefig example_tair_base.png
+    fig.show()
+
+Width-and-height constrained figure
+###################################
+    
+.. ipython:: python
+    :okwarning:
+
+    import matplotlib.pyplot as plt
+    import xarray as xr
+    from matplotlib import ticker
+    from faceted import faceted
+
+    tick_locator = ticker.MaxNLocator(nbins=3)
+    
+    ds = xr.tutorial.load_dataset('rasm').isel(x=slice(30, 37), y=-1,
+                                               time=slice(0, 11))
+    temp = ds.Tair
+    
+    fig, axes = faceted(2, 3, width=8, height=6.)
+    for i, ax in enumerate(axes):
+        temp.isel(x=i).plot(ax=ax, marker='o', ls='none')
+        ax.set_title('{:0.2f}'.format(temp.xc.isel(x=i).item()))
+        ax.set_xlabel('Time')
+        ax.set_ylabel('Temperature [C]')
+        ax.tick_params(axis='x', labelrotation=45)
+
+    @savefig example_tair_base.png
+    fig.show()
+
 Colorbar modes and locations
 ----------------------------
 

--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -19,7 +19,7 @@ illustrating the different features.  Using it in many ways resembles using
                                                time=slice(0, 11))
     temp = ds.Tair
     
-    fig, axes = faceted(2, 3, width=8)
+    fig, axes = faceted(2, 3, width=8, aspect=0.618)
     for i, ax in enumerate(axes):
         temp.isel(x=i).plot(ax=ax, marker='o', ls='none')
         ax.set_title('{:0.2f}'.format(temp.xc.isel(x=i).item()))
@@ -44,7 +44,7 @@ width.
 .. ipython:: python
     :okwarning:
 
-    fig, axes = faceted(2, 3, width=8, left_pad=0.75, bottom_pad=0.9,
+    fig, axes = faceted(2, 3, width=8, aspect=0.618, left_pad=0.75, bottom_pad=0.9,
                         internal_pad=(0.33, 0.66))
     for i, ax in enumerate(axes):
         temp.isel(x=i).plot(ax=ax, marker='o', ls='none')
@@ -75,7 +75,7 @@ from the time mean at each location in the lower row instead.
     mean = (ds.Tair * time_weights).sum('time') / time_weights.where(np.isfinite(ds.Tair)).sum('time')
     anomaly = ds.Tair - mean
     
-    fig, axes = faceted(2, 3, width=8, left_pad=0.75, bottom_pad=0.9,
+    fig, axes = faceted(2, 3, width=8, aspect=0.618, left_pad=0.75, bottom_pad=0.9,
                         internal_pad=(0.33, 0.66), sharey='row')
     for i, ax in enumerate(axes[:3]):
         temp.isel(x=i).plot(ax=ax, marker='o', ls='none')

--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -93,8 +93,8 @@ from the time mean at each location in the lower row instead.
     @savefig example_tair_share_axes.png
     fig.show()
 
-Other kinds of constraints
---------------------------
+Types of constrained figures
+----------------------------
 
 :py:meth:`faceted.faceted` supports multiple kinds of constrained figures.  We simply need
 to provide exactly two of the ``width``, ``height``, and ``aspect`` arguments and :py:meth:`faceted.faceted`

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,8 +1,8 @@
 faceted
 =======
 
-Figures with precise control over overall width, plot aspect ratio,
-between-plot spacing, and colorbar dimensions.
+Figures with precise control over overall width, overall height,
+plot aspect ratio, between-plot spacing, and colorbar dimensions.
 
 .. image:: example_tair_edge_cbar.png
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -9,6 +9,15 @@ What's New
 v0.2 (unreleased)
 =================
 
+- :py:meth:`faceted.faceted` now supports three types of constrained figures:
+  width-and-aspect constrained (as before), height-and-aspect constrained, and
+  width-and-height constrained.  Note the you must provide exactly two of the
+  ``width``, ``height``, and ``aspect`` arguments in your call.  A minor
+  breaking change is that defaults are no longer provided for ``width`` and
+  ``aspect`` (it would be cumbersome to have to override one of them with
+  ``None`` in the case of creating a height-and-aspect constrained or
+  width-and-height constrained figure).
+
 .. _whats-new.0.1:
 
 v0.1 (2019-03-07)

--- a/doc/why-faceted.rst
+++ b/doc/why-faceted.rst
@@ -341,8 +341,3 @@ main reason for creating :py:mod:`faceted` was that these other tools
 were *too* flexible at the expense of simplicity.  For a large percentage of
 the use cases, they are not required, but for the remaining percentage they are
 indeed quite useful.
-
-Currently only figures constrained by width and panel aspect ratio are
-possible in :py:mod:`faceted`.  That said, figures constrained by any two of
-the width, height, and panel aspect ratio would be within scope.  See
-:issue:`15` for discussion.

--- a/faceted/__init__.py
+++ b/faceted/__init__.py
@@ -1,4 +1,4 @@
-from .faceted import faceted, HeightConstrainedAxesGrid, HeightAndWidthConstrainedAxesGrid, WidthConstrainedAxesGrid
+from .faceted import faceted
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions

--- a/faceted/__init__.py
+++ b/faceted/__init__.py
@@ -1,4 +1,4 @@
-from .faceted import faceted, HeightConstrainedAxesGrid, WidthConstrainedAxesGrid
+from .faceted import faceted, HeightConstrainedAxesGrid, HeightAndWidthConstrainedAxesGrid, WidthConstrainedAxesGrid
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions

--- a/faceted/__init__.py
+++ b/faceted/__init__.py
@@ -1,4 +1,4 @@
-from .faceted import faceted, WidthConstrainedAxesGrid
+from .faceted import faceted, HeightConstrainedAxesGrid, WidthConstrainedAxesGrid
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions

--- a/faceted/faceted.py
+++ b/faceted/faceted.py
@@ -6,11 +6,11 @@ import numpy as np
 from mpl_toolkits.axes_grid1 import AxesGrid
 
 
-def faceted(rows, cols, width=8., aspect=0.618, top_pad=0.25,
+def faceted(rows, cols, width=8., height=None, aspect=0.618, top_pad=0.25,
             bottom_pad=0.25, left_pad=0.25, right_pad=0.25, internal_pad=0.33,
             cbar_mode=None, cbar_short_side_pad=0.0, cbar_pad=0.5,
             cbar_size=0.125, cbar_location='right', sharex='all', sharey='all',
-            axes_kwargs={}):
+            axes_kwargs=None):
     """Create figure and tiled axes objects with precise attributes.
 
     Parameters
@@ -21,6 +21,8 @@ def faceted(rows, cols, width=8., aspect=0.618, top_pad=0.25,
         Number of columns of tiles in figure
     width : float
         Width of figure
+    height : float
+        Height of figure
     aspect : float
         Aspect ratio of plots in each tile
     top_pad : float
@@ -66,14 +68,15 @@ def faceted(rows, cols, width=8., aspect=0.618, top_pad=0.25,
                          'float or a sequence of two values.  Got '
                          '{}'.format(internal_pad))
 
-    grid = WidthConstrainedAxesGrid(
-        rows, cols, width=width, aspect=aspect, top_pad=top_pad,
-        bottom_pad=bottom_pad, left_pad=left_pad, right_pad=right_pad,
-        cbar_mode=cbar_mode, cbar_location=cbar_location, cbar_pad=cbar_pad,
-        cbar_size=cbar_size, cbar_short_side_pad=cbar_short_side_pad,
-        axes_pad=internal_pad, sharex=sharex, sharey=sharey,
-        axes_kwargs=axes_kwargs
-    )
+    grid_class = _infer_grid_class(width, height, aspect)
+    grid = grid_class(
+            rows, cols, width=width, height=height, aspect=aspect, top_pad=top_pad,
+            bottom_pad=bottom_pad, left_pad=left_pad, right_pad=right_pad,
+            cbar_mode=cbar_mode, cbar_location=cbar_location, cbar_pad=cbar_pad,
+            cbar_size=cbar_size, cbar_short_side_pad=cbar_short_side_pad,
+            axes_pad=internal_pad, sharex=sharex, sharey=sharey,
+            axes_kwargs=axes_kwargs
+        )
     if cbar_mode is None:
         return grid.fig, grid.axes
     elif cbar_mode in ['each', 'edge', 'single']:
@@ -82,6 +85,22 @@ def faceted(rows, cols, width=8., aspect=0.618, top_pad=0.25,
 
 _LR = ['left', 'right']
 _BT = ['bottom', 'top']
+
+
+def _assert_valid_constraint(width, height, aspect):
+    constraints = (width, height, aspect)
+    if not (sum(constraint is not None for constraint in constraints) == 2):
+        raise ValueError("Exactly two of width, height, and aspect must be floats")
+
+
+def _infer_grid_class(width, height, aspect):
+    _assert_valid_constraint(width, height, aspect)
+    if width is not None and aspect is not None:
+        return WidthConstrainedAxesGrid
+    elif height is not None and aspect is not None:
+        return HeightConstrainedAxesGrid
+    else:
+        raise NotImplementedError()
 
 
 class CbarShortSidePadMixin(object):
@@ -210,19 +229,17 @@ class ShareAxesMixin(object):
                                          labeltop=False)
 
 
-class WidthConstrainedAxesGrid(CbarShortSidePadMixin, ShareAxesMixin):
-    """An AxesGrid object with a figure constrained to a precise width
-    with panels with a prescribed aspect ratio.
-    """
-    def __init__(self, rows, cols, width, top_pad=0., bottom_pad=0.,
+class ConstrainedAxesGrid(CbarShortSidePadMixin, ShareAxesMixin):
+    def __init__(self, rows, cols, width=None, height=None, aspect=None, top_pad=0., bottom_pad=0.,
                  left_pad=0., right_pad=0., cbar_size=0.125,
                  cbar_pad=0.125, axes_pad=(0.2, 0.2), cbar_mode=None,
-                 cbar_location='bottom', aspect=0.5, cbar_short_side_pad=0.,
-                 sharex=False, sharey=False, axes_kwargs={}):
+                 cbar_location='bottom', cbar_short_side_pad=0.,
+                 sharex=False, sharey=False, axes_kwargs=None):
         self.rows = rows
         self.cols = cols
-        self.width = width
-        self.aspect = aspect
+        self._width = width
+        self._height = height
+        self._aspect = aspect
 
         self.axes_pad = axes_pad
 
@@ -235,27 +252,23 @@ class WidthConstrainedAxesGrid(CbarShortSidePadMixin, ShareAxesMixin):
         self.cbar_size = cbar_size
         self.cbar_pad = cbar_pad
         self.cbar_location = cbar_location
+        self.cbar_short_side_pad = cbar_short_side_pad
 
         self._sharex = sharex
         self._sharey = sharey
-        self.axes_kwargs = axes_kwargs
 
-        # For some reason when the colorbar is placed at the bottom or left
-        # and the colorbar mode is 'single', AxesGrid adds an extra
-        # axes pad to the colorbar padding; we correct this manually here.
-        if self.cbar_location == 'bottom' and self.cbar_mode == 'single':
-            axes_grid_cbar_pad = self.cbar_pad - self.axes_pad[1]
-        elif self.cbar_location == 'left' and self.cbar_mode == 'single':
-            axes_grid_cbar_pad = self.cbar_pad - self.axes_pad[0]
+        if axes_kwargs is None:
+            self.axes_kwargs = {}
         else:
-            axes_grid_cbar_pad = self.cbar_pad
+            self.axes_kwargs = axes_kwargs
 
-        self.cbar_short_side_pad = cbar_short_side_pad
+        self.construct_axes()
 
+    def construct_axes(self):
         self.fig = plt.figure()
         self.grid = AxesGrid(
-            self.fig, self.rect(), nrows_ncols=(self.rows, self.cols),
-            cbar_size=self.cbar_size, cbar_pad=axes_grid_cbar_pad,
+            self.fig, self.rect, nrows_ncols=(self.rows, self.cols),
+            cbar_size=self.cbar_size, cbar_pad=self.axes_grid_cbar_pad,
             axes_pad=self.axes_pad, cbar_mode=self.cbar_mode,
             cbar_location=self.cbar_location, aspect=False
         )
@@ -264,6 +277,39 @@ class WidthConstrainedAxesGrid(CbarShortSidePadMixin, ShareAxesMixin):
         self.make_shared_ticklabels_invisible()
         self.caxes = self.resize_colorbars()
 
+    @property
+    def axes_grid_cbar_pad(self):
+        """For some reason the colorbar when the colorbar is placed at the
+        bottom or left and the colorbar mode is 'single', AxesGrid adds an
+        extra axes pad to the colorbar padding; we correct this manually
+        here.
+        """
+        horizontal_pad, vertical_pad = self.axes_pad
+        if self.cbar_location == 'bottom' and self.cbar_mode == 'single':
+            return self.cbar_pad - vertical_pad
+        elif self.cbar_location == 'left' and self.cbar_mode == 'single':
+            return self.cbar_pad - horizontal_pad
+        else:
+            return self.cbar_pad
+
+    @property
+    def rect(self):
+        """Compute the rect defining the area within the outer padding"""
+        x0 = self.left_pad / self.width
+        y0 = self.bottom_pad / self.height
+        width = (self.width - self.left_pad - self.right_pad) / self.width
+        height = (self.height - self.top_pad - self.bottom_pad) / self.height
+        return [x0, y0, width, height]
+
+
+# Interface for a subclass is:
+# define width, height, and aspect properties
+# define plot_height, and plot_width properties
+
+class WidthConstrainedAxesGrid(ConstrainedAxesGrid, CbarShortSidePadMixin, ShareAxesMixin):
+    """An AxesGrid object with a figure constrained to a precise width
+    with panels with a prescribed aspect ratio.
+    """
     @property
     def plot_width(self):
         """Width of plot area in each panel (in inches)"""
@@ -289,6 +335,16 @@ class WidthConstrainedAxesGrid(CbarShortSidePadMixin, ShareAxesMixin):
         return self.plot_width * self.aspect
 
     @property
+    def width(self):
+        """Width of the complete figure in inches"""
+        return self._width
+
+    @property
+    def aspect(self):
+        """Aspect ratio of each panel in the figure (height / width)"""
+        return self._aspect
+
+    @property
     def height(self):
         """Height of the complete figure in inches"""
         _, vpad = self.axes_pad
@@ -307,10 +363,60 @@ class WidthConstrainedAxesGrid(CbarShortSidePadMixin, ShareAxesMixin):
             return (total_plot_height + total_axes_pad + outer_pad +
                     cbar_width)
 
-    def rect(self):
-        """Compute the rect defining the area within the outer padding"""
-        x0 = self.left_pad / self.width
-        y0 = self.bottom_pad / self.height
-        width = (self.width - self.left_pad - self.right_pad) / self.width
-        height = (self.height - self.top_pad - self.bottom_pad) / self.height
-        return [x0, y0, width, height]
+
+class HeightConstrainedAxesGrid(ConstrainedAxesGrid, CbarShortSidePadMixin, ShareAxesMixin):
+    """An AxesGrid object with a figure constrained to a precise width
+    with panels with a prescribed aspect ratio.
+    """
+    @property
+    def plot_height(self):
+        """Height of plot area in each panel (in inches)"""
+        _, vertical_pad = self.axes_pad
+        inner_height = self.height - self.bottom_pad - self.top_pad
+        inner_pad = (self.rows - 1) * vertical_pad
+        cbar_width = self.cbar_pad + self.cbar_size
+
+        if self.cbar_mode is None or self.cbar_location in _LR:
+            return (inner_height - inner_pad) / self.rows
+        elif self.cbar_mode == 'each' and self.cbar_location in _BT:
+            return (inner_height - inner_pad
+                    - self.rows * cbar_width) / self.rows
+        elif (self.cbar_mode == 'single' or
+              self.cbar_mode == 'edge') and self.cbar_location in _BT:
+            return (inner_height - inner_pad - cbar_width) / self.rows
+        else:
+            raise ValueError('Invalid cbar_mode or cbar_location provided')
+
+    @property
+    def plot_width(self):
+        """Width of plot area in panel (in inches)"""
+        return self.plot_height / self.aspect
+
+    @property
+    def height(self):
+        """Height of the complete figure in inches"""
+        return self._height
+
+    @property
+    def aspect(self):
+        """Aspect ratio of each panel in the figure (height / width)"""
+        return self._aspect
+
+    @property
+    def width(self):
+        """Width of the complete figure in inches"""
+        horizontal_pad, _ = self.axes_pad
+        total_plot_width = self.cols * self.plot_width
+        total_axes_pad = (self.cols - 1) * horizontal_pad
+        outer_pad = self.left_pad + self.right_pad
+        cbar_width = self.cbar_size + self.cbar_pad
+
+        if self.cbar_mode is None or self.cbar_location in _BT:
+            return total_plot_height + total_axes_pad + outer_pad
+        elif self.cbar_mode == 'each' and self.cbar_location in _LR:
+            return (total_plot_width + total_axes_pad + outer_pad + self.cols
+                    * cbar_width)
+        elif (self.cbar_mode == 'single' or
+              self.cbar_mode == 'edge') and self.cbar_location in _LR:
+            return (total_plot_width + total_axes_pad + outer_pad +
+                    cbar_width)

--- a/faceted/faceted.py
+++ b/faceted/faceted.py
@@ -6,7 +6,7 @@ import numpy as np
 from mpl_toolkits.axes_grid1 import AxesGrid
 
 
-def faceted(rows, cols, width=8., height=None, aspect=0.618, top_pad=0.25,
+def faceted(rows, cols, width=None, height=None, aspect=None, top_pad=0.25,
             bottom_pad=0.25, left_pad=0.25, right_pad=0.25, internal_pad=0.33,
             cbar_mode=None, cbar_short_side_pad=0.0, cbar_pad=0.5,
             cbar_size=0.125, cbar_location='right', sharex='all', sharey='all',

--- a/faceted/faceted.py
+++ b/faceted/faceted.py
@@ -70,6 +70,8 @@ def faceted(rows, cols, width=None, height=None, aspect=None, top_pad=0.25,
         raise ValueError('Invalid internal pad provided; it must either be a '
                          'float or a sequence of two values.  Got '
                          '{}'.format(internal_pad))
+    if cbar_mode not in [None, 'single', 'edge', 'each']:
+        raise ValueError(f'Invalid cbar mode provided.  Got {cbar_mode}.')
 
     grid_class = _infer_grid_class(width, height, aspect)
     grid = grid_class(
@@ -325,8 +327,6 @@ class WidthConstrainedAxesGrid(ConstrainedAxesGrid, CbarShortSidePadMixin, Share
         elif (self.cbar_mode == 'single' or
               self.cbar_mode == 'edge') and self.cbar_location in _LR:
             return (inner_width - inner_pad - cbar_width) / self.cols
-        else:
-            raise ValueError('Invalid cbar_mode or cbar_location provided')
 
     @property
     def plot_height(self):
@@ -383,8 +383,6 @@ class HeightConstrainedAxesGrid(ConstrainedAxesGrid, CbarShortSidePadMixin, Shar
         elif (self.cbar_mode == 'single' or
               self.cbar_mode == 'edge') and self.cbar_location in _BT:
             return (inner_height - inner_pad - cbar_width) / self.rows
-        else:
-            raise ValueError('Invalid cbar_mode or cbar_location provided')
 
     @property
     def plot_width(self):
@@ -441,8 +439,6 @@ class HeightAndWidthConstrainedAxesGrid(ConstrainedAxesGrid, CbarShortSidePadMix
         elif (self.cbar_mode == 'single' or
               self.cbar_mode == 'edge') and self.cbar_location in _LR:
             return (inner_width - inner_pad - cbar_width) / self.cols
-        else:
-            raise ValueError('Invalid cbar_mode or cbar_location provided')
 
     @property
     def plot_height(self):
@@ -460,8 +456,6 @@ class HeightAndWidthConstrainedAxesGrid(ConstrainedAxesGrid, CbarShortSidePadMix
         elif (self.cbar_mode == 'single' or
               self.cbar_mode == 'edge') and self.cbar_location in _BT:
             return (inner_height - inner_pad - cbar_width) / self.rows
-        else:
-            raise ValueError('Invalid cbar_mode or cbar_location provided')
 
     @property
     def height(self):

--- a/faceted/faceted.py
+++ b/faceted/faceted.py
@@ -412,7 +412,7 @@ class HeightConstrainedAxesGrid(ConstrainedAxesGrid, CbarShortSidePadMixin, Shar
         cbar_width = self.cbar_size + self.cbar_pad
 
         if self.cbar_mode is None or self.cbar_location in _BT:
-            return total_plot_height + total_axes_pad + outer_pad
+            return total_plot_width + total_axes_pad + outer_pad
         elif self.cbar_mode == 'each' and self.cbar_location in _LR:
             return (total_plot_width + total_axes_pad + outer_pad + self.cols
                     * cbar_width)

--- a/faceted/faceted.py
+++ b/faceted/faceted.py
@@ -13,6 +13,9 @@ def faceted(rows, cols, width=8., height=None, aspect=0.618, top_pad=0.25,
             axes_kwargs=None):
     """Create figure and tiled axes objects with precise attributes.
 
+    Exactly two of width, height, and aspect must be defined.  The third is
+    inferred based on the other two values.
+
     Parameters
     ----------
     rows : int

--- a/faceted/tests/test_faceted.py
+++ b/faceted/tests/test_faceted.py
@@ -6,7 +6,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
-from faceted import faceted, HeightConstrainedAxesGrid, HeightAndWidthConstrainedAxesGrid, WidthConstrainedAxesGrid
+from ..faceted import faceted, _infer_grid_class, HeightConstrainedAxesGrid, HeightAndWidthConstrainedAxesGrid, WidthConstrainedAxesGrid
 
 
 plt.switch_backend('agg')
@@ -51,6 +51,18 @@ def test_faceted_cbar_mode_invalid():
 def test_faceted_invalid_internal_pad():
     with pytest.raises(ValueError):
         faceted(1, 2, internal_pad=(1, 2, 3))
+
+
+@pytest.mark.parametrize(('width', 'height', 'aspect'), [(None, None, None), (5., None, None), (None, 5., None), (None, None, 5.), (5., 5., 5.)])
+def test_faceted_invalid_constraints(width, height, aspect):
+    with pytest.raises(ValueError, match='Exactly'):
+        faceted(1, 2, width=width, height=height, aspect=aspect)
+
+
+@pytest.mark.parametrize(('width', 'height', 'aspect', 'expected'), [(5., 5., None, HeightAndWidthConstrainedAxesGrid), (5., None, 5., WidthConstrainedAxesGrid), (None, 5., 5., HeightConstrainedAxesGrid)])
+def test__infer_grid_class(width, height, aspect, expected):
+    result = _infer_grid_class(width, height, aspect)
+    assert result == expected
 
 
 _LAYOUTS = [(1, 1), (1, 2), (2, 1), (2, 2), (5, 3)]
@@ -413,7 +425,6 @@ def assert_visible_xticklabels(ax):
 
 
 def assert_invisible_xticklabels(ax):
-    print(dir(ax.xaxis._get_tick(ax.xaxis.major)))
     assert not ax.xaxis._get_tick(ax.xaxis.major).label1.get_visible()
     assert not ax.xaxis._get_tick(ax.xaxis.minor).label1.get_visible()
 

--- a/faceted/tests/test_faceted.py
+++ b/faceted/tests/test_faceted.py
@@ -6,7 +6,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
-from faceted import faceted, WidthConstrainedAxesGrid
+from faceted import faceted, HeightConstrainedAxesGrid, WidthConstrainedAxesGrid
 
 
 plt.switch_backend('agg')
@@ -17,6 +17,7 @@ _HORIZONTAL_INTERNAL_PAD = 0.25
 _VERTICAL_INTERNAL_PAD = 0.5
 _INTERNAL_PAD = (_HORIZONTAL_INTERNAL_PAD, _VERTICAL_INTERNAL_PAD)
 _ASPECT = 0.5
+_HEIGHT_CONSTRAINT = 7.
 _WIDTH_CONSTRAINT = 8.
 _SHORT_SIDE_PAD = 0.25
 _LONG_SIDE_PAD = 0.25
@@ -55,13 +56,14 @@ def test_faceted_invalid_internal_pad():
 _LAYOUTS = [(1, 1), (1, 2), (2, 1), (2, 2), (5, 3)]
 _CBAR_MODES = [None, 'single', 'each', 'edge']
 _CBAR_LOCATIONS = ['bottom', 'right', 'top', 'left']
-_CG_LAYOUTS = product(_CBAR_MODES, _CBAR_LOCATIONS, _LAYOUTS)
+_CONSTRAINTS = ['height', 'width']
+_CG_LAYOUTS = product(_CBAR_MODES, _CBAR_LOCATIONS, _LAYOUTS, _CONSTRAINTS)
 
 
 def format_layout(layout):
-    cbar_mode, cbar_loc, (rows, cols) = layout
-    return 'cbar_mode={!r}, cbar_location={!r}, rows={}, cols={}'.format(
-        cbar_mode, cbar_loc, rows, cols)
+    cbar_mode, cbar_loc, (rows, cols), constraint = layout
+    return 'cbar_mode={!r}, cbar_location={!r}, rows={}, cols={}, constraint={}'.format(
+        cbar_mode, cbar_loc, rows, cols, constraint)
 
 
 _CG_IDS = OrderedDict([(layout, format_layout(layout))
@@ -70,15 +72,27 @@ _CG_IDS = OrderedDict([(layout, format_layout(layout))
 
 @pytest.fixture(params=_CG_IDS.keys(), ids=_CG_IDS.values())
 def grid(request):
-    mode, location, (rows, cols) = request.param
-    obj = WidthConstrainedAxesGrid(
-        rows, cols, width=_WIDTH_CONSTRAINT, aspect=_ASPECT,
-        top_pad=_TOP_PAD, bottom_pad=_BOTTOM_PAD,
-        left_pad=_LEFT_PAD, right_pad=_RIGHT_PAD,
-        cbar_mode=mode, cbar_pad=_LONG_SIDE_PAD,
-        axes_pad=_INTERNAL_PAD, cbar_location=location,
-        cbar_size=_CBAR_THICKNESS,
-        cbar_short_side_pad=_SHORT_SIDE_PAD)
+    mode, location, (rows, cols), constraint = request.param
+    if constraint == 'width':
+        obj = WidthConstrainedAxesGrid(
+            rows, cols, width=_WIDTH_CONSTRAINT, aspect=_ASPECT,
+            top_pad=_TOP_PAD, bottom_pad=_BOTTOM_PAD,
+            left_pad=_LEFT_PAD, right_pad=_RIGHT_PAD,
+            cbar_mode=mode, cbar_pad=_LONG_SIDE_PAD,
+            axes_pad=_INTERNAL_PAD, cbar_location=location,
+            cbar_size=_CBAR_THICKNESS,
+            cbar_short_side_pad=_SHORT_SIDE_PAD)
+    elif constraint == 'height':
+        obj = HeightConstrainedAxesGrid(
+            rows, cols, height=_HEIGHT_CONSTRAINT, aspect=_ASPECT,
+            top_pad=_TOP_PAD, bottom_pad=_BOTTOM_PAD,
+            left_pad=_LEFT_PAD, right_pad=_RIGHT_PAD,
+            cbar_mode=mode, cbar_pad=_LONG_SIDE_PAD,
+            axes_pad=_INTERNAL_PAD, cbar_location=location,
+            cbar_size=_CBAR_THICKNESS,
+            cbar_short_side_pad=_SHORT_SIDE_PAD)
+    else:
+        raise NotImplementedError()
     yield obj
     plt.close(obj.fig)
 

--- a/faceted/tests/test_faceted.py
+++ b/faceted/tests/test_faceted.py
@@ -6,7 +6,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
-from faceted import faceted, HeightConstrainedAxesGrid, WidthConstrainedAxesGrid
+from faceted import faceted, HeightConstrainedAxesGrid, HeightAndWidthConstrainedAxesGrid, WidthConstrainedAxesGrid
 
 
 plt.switch_backend('agg')
@@ -16,7 +16,7 @@ _TOP_PAD = _BOTTOM_PAD = _LEFT_PAD = _RIGHT_PAD = 0.25
 _HORIZONTAL_INTERNAL_PAD = 0.25
 _VERTICAL_INTERNAL_PAD = 0.5
 _INTERNAL_PAD = (_HORIZONTAL_INTERNAL_PAD, _VERTICAL_INTERNAL_PAD)
-_ASPECT = 0.5
+_ASPECT_CONSTRAINT = 0.5
 _HEIGHT_CONSTRAINT = 7.
 _WIDTH_CONSTRAINT = 8.
 _SHORT_SIDE_PAD = 0.25
@@ -56,7 +56,7 @@ def test_faceted_invalid_internal_pad():
 _LAYOUTS = [(1, 1), (1, 2), (2, 1), (2, 2), (5, 3)]
 _CBAR_MODES = [None, 'single', 'each', 'edge']
 _CBAR_LOCATIONS = ['bottom', 'right', 'top', 'left']
-_CONSTRAINTS = ['height', 'width']
+_CONSTRAINTS = ['height', 'width', 'height-and-width']
 _CG_LAYOUTS = product(_CBAR_MODES, _CBAR_LOCATIONS, _LAYOUTS, _CONSTRAINTS)
 
 
@@ -75,7 +75,7 @@ def grid(request):
     mode, location, (rows, cols), constraint = request.param
     if constraint == 'width':
         obj = WidthConstrainedAxesGrid(
-            rows, cols, width=_WIDTH_CONSTRAINT, aspect=_ASPECT,
+            rows, cols, width=_WIDTH_CONSTRAINT, aspect=_ASPECT_CONSTRAINT,
             top_pad=_TOP_PAD, bottom_pad=_BOTTOM_PAD,
             left_pad=_LEFT_PAD, right_pad=_RIGHT_PAD,
             cbar_mode=mode, cbar_pad=_LONG_SIDE_PAD,
@@ -84,7 +84,16 @@ def grid(request):
             cbar_short_side_pad=_SHORT_SIDE_PAD)
     elif constraint == 'height':
         obj = HeightConstrainedAxesGrid(
-            rows, cols, height=_HEIGHT_CONSTRAINT, aspect=_ASPECT,
+            rows, cols, height=_HEIGHT_CONSTRAINT, aspect=_ASPECT_CONSTRAINT,
+            top_pad=_TOP_PAD, bottom_pad=_BOTTOM_PAD,
+            left_pad=_LEFT_PAD, right_pad=_RIGHT_PAD,
+            cbar_mode=mode, cbar_pad=_LONG_SIDE_PAD,
+            axes_pad=_INTERNAL_PAD, cbar_location=location,
+            cbar_size=_CBAR_THICKNESS,
+            cbar_short_side_pad=_SHORT_SIDE_PAD)
+    elif constraint == 'height-and-width':
+        obj = HeightAndWidthConstrainedAxesGrid(
+            rows, cols, height=_HEIGHT_CONSTRAINT, width=_WIDTH_CONSTRAINT,
             top_pad=_TOP_PAD, bottom_pad=_BOTTOM_PAD,
             left_pad=_LEFT_PAD, right_pad=_RIGHT_PAD,
             cbar_mode=mode, cbar_pad=_LONG_SIDE_PAD,
@@ -107,24 +116,24 @@ def get_tile_height(grid, bottom_pad=_BOTTOM_PAD, top_pad=_TOP_PAD):
             (grid.rows - 1) * _VERTICAL_INTERNAL_PAD) / grid.rows
 
 
-def test_width_constrained_axes_positions(grid):
+def test_constrained_axes_positions(grid):
     if grid.cbar_mode == 'each':
-        check_width_constrained_axes_positions_each(grid)
+        check_constrained_axes_positions_each(grid)
     elif grid.cbar_mode == 'single':
-        check_width_constrained_axes_positions_single(grid)
+        check_constrained_axes_positions_single(grid)
     elif grid.cbar_mode == 'edge':
-        check_width_constrained_axes_positions_edge(grid)
+        check_constrained_axes_positions_edge(grid)
     elif grid.cbar_mode is None:
-        check_width_constrained_axes_positions_none(grid)
+        check_constrained_axes_positions_none(grid)
 
 
-def test_width_constrained_caxes_positions(grid):
+def test_constrained_caxes_positions(grid):
     if grid.cbar_mode == 'each':
-        check_width_constrained_caxes_positions_each(grid)
+        check_constrained_caxes_positions_each(grid)
     elif grid.cbar_mode == 'single':
-        check_width_constrained_caxes_positions_single(grid)
+        check_constrained_caxes_positions_single(grid)
     elif grid.cbar_mode == 'edge':
-        check_width_constrained_caxes_positions_edge(grid)
+        check_constrained_caxes_positions_edge(grid)
     elif grid.cbar_mode is None:
         pytest.skip('Skipping colorbar positions test, because cbar_mode=None')
 
@@ -142,7 +151,7 @@ def test_plot_aspect(grid):
         np.testing.assert_allclose(result, expected)
 
 
-def check_width_constrained_axes_positions_none(grid):
+def check_constrained_axes_positions_none(grid):
     rows, cols = grid.rows, grid.cols
     width, height = grid.width, grid.height
     tile_width, tile_height = get_tile_width(grid), get_tile_height(grid)
@@ -161,7 +170,7 @@ def check_width_constrained_axes_positions_none(grid):
         np.testing.assert_allclose(ax_bounds, expected_bounds)
 
 
-def check_width_constrained_axes_positions_single(grid):
+def check_constrained_axes_positions_single(grid):
     rows, cols = grid.rows, grid.cols
     width, height = grid.width, grid.height
     cbar_location = grid.cbar_location
@@ -194,7 +203,7 @@ def check_width_constrained_axes_positions_single(grid):
         np.testing.assert_allclose(ax_bounds, expected_bounds)
 
 
-def check_width_constrained_caxes_positions_single(grid):
+def check_constrained_caxes_positions_single(grid):
     width, height = grid.width, grid.height
     cbar_location = grid.cbar_location
     fig = grid.fig
@@ -225,7 +234,7 @@ def check_width_constrained_caxes_positions_single(grid):
     np.testing.assert_allclose(cax_bounds, expected_bounds)
 
 
-def check_width_constrained_axes_positions_each(grid):
+def check_constrained_axes_positions_each(grid):
     rows, cols = grid.rows, grid.cols
     width, height = grid.width, grid.height
     tile_width, tile_height = get_tile_width(grid), get_tile_height(grid)
@@ -281,7 +290,7 @@ def check_width_constrained_axes_positions_each(grid):
             np.testing.assert_allclose(ax_bounds, expected_bounds)
 
 
-def check_width_constrained_caxes_positions_each(grid):
+def check_constrained_caxes_positions_each(grid):
     rows, cols = grid.rows, grid.cols
     width, height = grid.width, grid.height
     tile_width, tile_height = get_tile_width(grid), get_tile_height(grid)
@@ -337,12 +346,12 @@ def check_width_constrained_caxes_positions_each(grid):
             np.testing.assert_allclose(cax_bounds, expected_bounds)
 
 
-def check_width_constrained_axes_positions_edge(grid):
+def check_constrained_axes_positions_edge(grid):
     # The positions of the axes are the same as for cbar_mode='single'
-    check_width_constrained_axes_positions_single(grid)
+    check_constrained_axes_positions_single(grid)
 
 
-def check_width_constrained_caxes_positions_edge(grid):
+def check_constrained_caxes_positions_edge(grid):
     rows, cols = grid.rows, grid.cols
     width, height = grid.width, grid.height
     tile_width, tile_height = get_tile_width(grid), get_tile_height(grid)
@@ -394,7 +403,7 @@ def check_width_constrained_caxes_positions_edge(grid):
 
 def shared_grid(sharex, sharey):
     return WidthConstrainedAxesGrid(
-        2, 2, width=_WIDTH_CONSTRAINT, aspect=_ASPECT, sharex=sharex, sharey=sharey,
+        2, 2, width=_WIDTH_CONSTRAINT, aspect=_ASPECT_CONSTRAINT, sharex=sharex, sharey=sharey,
         cbar_mode='single')
 
 

--- a/faceted/tests/test_faceted.py
+++ b/faceted/tests/test_faceted.py
@@ -43,9 +43,10 @@ def test_faceted_cbar_mode_each():
     plt.close(fig)
 
 
-def test_faceted_cbar_mode_invalid():
+@pytest.mark.parametrize(('width', 'height', 'aspect'), [(1, 1, None), (1, None, 1), (None, 1, 1)])
+def test_faceted_cbar_mode_invalid(width, height, aspect):
     with pytest.raises(ValueError):
-        faceted(1, 2, width=_WIDTH_CONSTRAINT, aspect=_ASPECT_CONSTRAINT, cbar_mode='invalid')
+        faceted(1, 2, width=width, height=height, aspect=aspect, cbar_mode='invalid')
 
 
 def test_faceted_invalid_internal_pad():

--- a/faceted/tests/test_faceted.py
+++ b/faceted/tests/test_faceted.py
@@ -25,19 +25,19 @@ _CBAR_THICKNESS = 0.125
 
 
 def test_faceted_cbar_mode_none():
-    fig, axes = faceted(1, 2)
+    fig, axes = faceted(1, 2, width=_WIDTH_CONSTRAINT, aspect=_ASPECT_CONSTRAINT)
     assert len(axes) == 2
     plt.close(fig)
 
 
 def test_faceted_cbar_mode_single():
-    fig, axes, cax = faceted(1, 2, cbar_mode='single')
+    fig, axes, cax = faceted(1, 2, width=_WIDTH_CONSTRAINT, aspect=_ASPECT_CONSTRAINT, cbar_mode='single')
     assert len(axes) == 2
     plt.close(fig)
 
 
 def test_faceted_cbar_mode_each():
-    fig, axes, caxes = faceted(1, 2, cbar_mode='each')
+    fig, axes, caxes = faceted(1, 2, width=_WIDTH_CONSTRAINT, aspect=_ASPECT_CONSTRAINT, cbar_mode='each')
     assert len(axes) == 2
     assert len(axes) == len(caxes)
     plt.close(fig)
@@ -45,12 +45,12 @@ def test_faceted_cbar_mode_each():
 
 def test_faceted_cbar_mode_invalid():
     with pytest.raises(ValueError):
-        faceted(1, 2, cbar_mode='invalid')
+        faceted(1, 2, width=_WIDTH_CONSTRAINT, aspect=_ASPECT_CONSTRAINT, cbar_mode='invalid')
 
 
 def test_faceted_invalid_internal_pad():
     with pytest.raises(ValueError):
-        faceted(1, 2, internal_pad=(1, 2, 3))
+        faceted(1, 2, width=_WIDTH_CONSTRAINT, aspect=_ASPECT_CONSTRAINT, internal_pad=(1, 2, 3))
 
 
 @pytest.mark.parametrize(('width', 'height', 'aspect'), [(None, None, None), (5., None, None), (None, 5., None), (None, None, 5.), (5., 5., 5.)])
@@ -552,7 +552,7 @@ def test_cartopy():
     import cartopy.crs as ccrs
     from cartopy.mpl.geoaxes import GeoAxes
 
-    fig, axes = faceted(2, 2, axes_kwargs={'projection': ccrs.PlateCarree()})
+    fig, axes = faceted(2, 2, width=_WIDTH_CONSTRAINT, aspect=_ASPECT_CONSTRAINT, axes_kwargs={'projection': ccrs.PlateCarree()})
     for ax in axes:
         assert isinstance(ax, GeoAxes)
     plt.close(fig)

--- a/faceted/tests/test_faceted.py
+++ b/faceted/tests/test_faceted.py
@@ -68,7 +68,7 @@ def test__infer_grid_class(width, height, aspect, expected):
 _LAYOUTS = [(1, 1), (1, 2), (2, 1), (2, 2), (5, 3)]
 _CBAR_MODES = [None, 'single', 'each', 'edge']
 _CBAR_LOCATIONS = ['bottom', 'right', 'top', 'left']
-_CONSTRAINTS = ['height', 'width', 'height-and-width']
+_CONSTRAINTS = ['height-and-aspect', 'width-and-aspect', 'height-and-width']
 _CG_LAYOUTS = product(_CBAR_MODES, _CBAR_LOCATIONS, _LAYOUTS, _CONSTRAINTS)
 
 
@@ -85,7 +85,7 @@ _CG_IDS = OrderedDict([(layout, format_layout(layout))
 @pytest.fixture(params=_CG_IDS.keys(), ids=_CG_IDS.values())
 def grid(request):
     mode, location, (rows, cols), constraint = request.param
-    if constraint == 'width':
+    if constraint == 'width-and-aspect':
         obj = WidthConstrainedAxesGrid(
             rows, cols, width=_WIDTH_CONSTRAINT, aspect=_ASPECT_CONSTRAINT,
             top_pad=_TOP_PAD, bottom_pad=_BOTTOM_PAD,
@@ -94,7 +94,7 @@ def grid(request):
             axes_pad=_INTERNAL_PAD, cbar_location=location,
             cbar_size=_CBAR_THICKNESS,
             cbar_short_side_pad=_SHORT_SIDE_PAD)
-    elif constraint == 'height':
+    elif constraint == 'height-and-aspect':
         obj = HeightConstrainedAxesGrid(
             rows, cols, height=_HEIGHT_CONSTRAINT, aspect=_ASPECT_CONSTRAINT,
             top_pad=_TOP_PAD, bottom_pad=_BOTTOM_PAD,

--- a/faceted/tests/test_faceted.py
+++ b/faceted/tests/test_faceted.py
@@ -380,28 +380,29 @@ def check_width_constrained_caxes_positions_edge(grid):
 
 def shared_grid(sharex, sharey):
     return WidthConstrainedAxesGrid(
-        2, 2, _WIDTH_CONSTRAINT, sharex=sharex, sharey=sharey,
+        2, 2, width=_WIDTH_CONSTRAINT, aspect=_ASPECT, sharex=sharex, sharey=sharey,
         cbar_mode='single')
 
 
 def assert_visible_xticklabels(ax):
-    assert ax.xaxis._get_tick(ax.xaxis.major).label1On
-    assert ax.xaxis._get_tick(ax.xaxis.minor).label1On
+    assert ax.xaxis._get_tick(ax.xaxis.major).label1.get_visible()
+    assert ax.xaxis._get_tick(ax.xaxis.minor).label1.get_visible()
 
 
 def assert_invisible_xticklabels(ax):
-    assert not ax.xaxis._get_tick(ax.xaxis.major).label1On
-    assert not ax.xaxis._get_tick(ax.xaxis.minor).label1On
+    print(dir(ax.xaxis._get_tick(ax.xaxis.major)))
+    assert not ax.xaxis._get_tick(ax.xaxis.major).label1.get_visible()
+    assert not ax.xaxis._get_tick(ax.xaxis.minor).label1.get_visible()
 
 
 def assert_visible_yticklabels(ax):
-    assert ax.yaxis._get_tick(ax.yaxis.major).label1On
-    assert ax.yaxis._get_tick(ax.yaxis.minor).label1On
+    assert ax.yaxis._get_tick(ax.yaxis.major).label1.get_visible()
+    assert ax.yaxis._get_tick(ax.yaxis.minor).label1.get_visible()
 
 
 def assert_invisible_yticklabels(ax):
-    assert not ax.yaxis._get_tick(ax.yaxis.major).label1On
-    assert not ax.yaxis._get_tick(ax.yaxis.minor).label1On
+    assert not ax.yaxis._get_tick(ax.yaxis.major).label1.get_visible()
+    assert not ax.yaxis._get_tick(ax.yaxis.minor).label1.get_visible()
 
 
 def assert_valid_x_sharing(shared_grid, sharex):


### PR DESCRIPTION
Closes #15 

This generalizes `faceted` so that in addition to creating width-and-aspect constrained figures, it can also create height-and-aspect and width-and-height constrained figures.  It also includes some updates to the tests for compatibility with the latest matplotlib version.