### PR TITLE
Minor cleanups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ matrix:
     fast_finish: true
     include:
     - python: 3.6
-      env: CONDA_ENV=docs
-    - python: 3.6
       env: CONDA_ENV=py36
+    - python: 3.6
+      env: CONDA_ENV=docs
 
 before_install:
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
@@ -39,6 +39,7 @@ script:
   - if [[ "$CONDA_ENV" == "docs" ]]; then
       cd doc;
       sphinx-build -n -j auto -b html -d _build/doctrees . _build/html;
+      py.test faceted --cov=faceted --cov-report term-missing --verbose;
     else
       black --check --exclude _version.py .;
       py.test faceted --cov=faceted --cov-report term-missing --verbose;

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ matrix:
     fast_finish: true
     include:
     - python: 3.6
-      env: CONDA_ENV=py36
-    - python: 3.6
       env: CONDA_ENV=docs
+    - python: 3.6
+      env: CONDA_ENV=py36
 
 before_install:
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,9 @@ script:
   - which python
   - python --version
   - if [[ "$CONDA_ENV" == "docs" ]]; then
+      py.test faceted --cov=faceted --cov-report term-missing --verbose;
       cd doc;
       sphinx-build -n -j auto -b html -d _build/doctrees . _build/html;
-      py.test faceted --cov=faceted --cov-report term-missing --verbose;
     else
       black --check --exclude _version.py .;
       py.test faceted --cov=faceted --cov-report term-missing --verbose;

--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -119,7 +119,8 @@ This is what we've shown already, but for completeness we'll repeat the example 
                                                time=slice(0, 11))
     temp = ds.Tair
     
-    fig, axes = faceted(2, 3, width=8, aspect=0.618)
+    fig, axes = faceted(2, 3, width=8, aspect=0.618, bottom_pad=0.9, left_pad=0.75,
+                        internal_pad=(0.33, 0.66), sharey='row')
     for i, ax in enumerate(axes):
         temp.isel(x=i).plot(ax=ax, marker='o', ls='none')
         ax.set_title('{:0.2f}'.format(temp.xc.isel(x=i).item()))
@@ -127,7 +128,7 @@ This is what we've shown already, but for completeness we'll repeat the example 
         ax.set_ylabel('Temperature [C]')
         ax.tick_params(axis='x', labelrotation=45)
 
-    @savefig example_tair_base.png
+    @savefig example_tair_base_width_and_aspect.png
     fig.show()
 
 Height-and-aspect constrained figure
@@ -147,7 +148,8 @@ Height-and-aspect constrained figure
                                                time=slice(0, 11))
     temp = ds.Tair
     
-    fig, axes = faceted(2, 3, height=8., aspect=0.618)
+    fig, axes = faceted(2, 3, height=8., aspect=0.618, bottom_pad=0.9, left_pad=0.75,
+                        internal_pad=(0.33, 0.66), sharey='row')
     for i, ax in enumerate(axes):
         temp.isel(x=i).plot(ax=ax, marker='o', ls='none')
         ax.set_title('{:0.2f}'.format(temp.xc.isel(x=i).item()))
@@ -155,7 +157,7 @@ Height-and-aspect constrained figure
         ax.set_ylabel('Temperature [C]')
         ax.tick_params(axis='x', labelrotation=45)
 
-    @savefig example_tair_base.png
+    @savefig example_tair_base_height_and_aspect.png
     fig.show()
 
 Width-and-height constrained figure
@@ -175,7 +177,8 @@ Width-and-height constrained figure
                                                time=slice(0, 11))
     temp = ds.Tair
     
-    fig, axes = faceted(2, 3, width=8, height=6.)
+    fig, axes = faceted(2, 3, width=8, height=6., bottom_pad=0.9, left_pad=0.75,
+                        internal_pad=(0.33, 0.66), sharey='row')
     for i, ax in enumerate(axes):
         temp.isel(x=i).plot(ax=ax, marker='o', ls='none')
         ax.set_title('{:0.2f}'.format(temp.xc.isel(x=i).item()))
@@ -183,7 +186,7 @@ Width-and-height constrained figure
         ax.set_ylabel('Temperature [C]')
         ax.tick_params(axis='x', labelrotation=45)
 
-    @savefig example_tair_base.png
+    @savefig example_tair_base_width_and_height.png
     fig.show()
 
 Colorbar modes and locations
@@ -209,22 +212,22 @@ a figure.
 
     import cartopy.crs as ccrs
 
-    ds = xr.tutorial.load_dataset('rasm')
-    
-    aspect = 75. / 180.
+    ds = xr.tutorial.load_dataset('air_temperature')
+
+    aspect = 60. / 130.
     fig, axes, cax = faceted(2, 3, width=8, aspect=aspect,
-                             bottom_pad=0.75, cbar_mode='single',
-                             cbar_pad=0.1, internal_pad=0.1,
-                             cbar_location='bottom', cbar_short_side_pad=0.,
-                             axes_kwargs={'projection': ccrs.PlateCarree()})
+                            bottom_pad=0.75, cbar_mode='single',
+                            cbar_pad=0.1, internal_pad=0.1,
+                            cbar_location='bottom', cbar_short_side_pad=0.,
+                            axes_kwargs={'projection': ccrs.PlateCarree()})
     for i, ax in enumerate(axes):
-        c = ds.Tair.isel(time=i).plot(
+        c = ds.air.isel(time=i).plot(
             ax=ax, add_colorbar=False, transform=ccrs.PlateCarree(),
-            vmin=-30, vmax=30, x='xc', y='yc')
+            vmin=230, vmax=305)
         ax.set_title('')
         ax.set_xlabel('')
         ax.set_ylabel('')
-        ax.set_extent([-180, 0, 15, 90], crs=ccrs.PlateCarree())
+        ax.set_extent([-160, -30, 15, 75], crs=ccrs.PlateCarree())
         ax.coastlines()
 
     plt.colorbar(c, cax=cax, orientation='horizontal', label='Temperature [C]');
@@ -241,32 +244,32 @@ We'll show an example where the rows share a colorbar.
 .. ipython:: python
     :okwarning:
 
-    aspect = 75. / 180.
+    aspect = 60. / 130.
     fig, axes, (cax1, cax2) = faceted(2, 3, width=8, aspect=aspect, right_pad=0.75,
                                       cbar_mode='edge',
                                       cbar_pad=0.1, internal_pad=0.1,
                                       cbar_location='right', cbar_short_side_pad=0.,
                                       axes_kwargs={'projection': ccrs.PlateCarree()})
     for i, ax in enumerate(axes[:3]):
-        c1 = ds.Tair.isel(time=i).plot(
+        c1 = ds.air.isel(time=i).plot(
             ax=ax, add_colorbar=False, transform=ccrs.PlateCarree(),
-            vmin=-30, vmax=30, x='xc', y='yc')
+            vmin=230, vmax=305)
         ax.set_title('')
         ax.set_xlabel('')
         ax.set_ylabel('')
-        ax.set_extent([180, 360, 15, 90], crs=ccrs.PlateCarree())
+        ax.set_extent([-160, -30, 15, 75], crs=ccrs.PlateCarree())
         ax.coastlines()
 
     plt.colorbar(c1, cax=cax1, label='[C]');
 
     for i, ax in enumerate(axes[3:], start=3):
-        c2 = ds.Tair.isel(time=i).plot(
+        c2 = ds.air.isel(time=i).plot(
             ax=ax, add_colorbar=False, transform=ccrs.PlateCarree(),
-            vmin=-50, vmax=50, x='xc', y='yc')
+            vmin=230, vmax=305)
         ax.set_title('')
         ax.set_xlabel('')
         ax.set_ylabel('')
-        ax.set_extent([-180, 0, 15, 90], crs=ccrs.PlateCarree())
+        ax.set_extent([-160, -30, 15, 75], crs=ccrs.PlateCarree())
         ax.coastlines()
 
     plt.colorbar(c2, cax=cax2, label='[C]');
@@ -285,20 +288,20 @@ specifying ``cbar_mode='each'`` as an argument in the call to :py:meth:`faceted.
 
     tick_locator = ticker.MaxNLocator(nbins=3)
     
-    aspect = 75. / 180.
+    aspect = 60. / 130.
     fig, axes, caxes = faceted(2, 3, width=8, aspect=aspect, right_pad=0.75,
                                cbar_mode='each',
                                cbar_pad=0.1, internal_pad=(0.75, 0.1),
                                cbar_location='right', cbar_short_side_pad=0.,
                                axes_kwargs={'projection': ccrs.PlateCarree()})
     for i, (ax, cax) in enumerate(zip(axes, caxes)):
-        c = ds.Tair.isel(time=i).plot(
+        c = ds.air.isel(time=i).plot(
             ax=ax, add_colorbar=False, transform=ccrs.PlateCarree(),
-            x='xc', y='yc', cmap='viridis')
+            cmap='viridis', vmin=230, vmax=305)
         ax.set_title('')
         ax.set_xlabel('')
         ax.set_ylabel('')
-        ax.set_extent([-180, 0, 15, 90], crs=ccrs.PlateCarree())
+        ax.set_extent([-160, -30, 15, 75], crs=ccrs.PlateCarree())
         ax.coastlines()
         cb = plt.colorbar(c, cax=cax, label='[C]')
         cb.locator = tick_locator

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -6,7 +6,7 @@ What's New
 
 .. _whats-new.0.2:
 
-v0.2 (unreleased)
+v0.2 (2020-12-06)
 =================
 
 - :py:meth:`faceted.faceted` now supports three types of constrained figures:

--- a/doc/why-faceted.rst
+++ b/doc/why-faceted.rst
@@ -15,14 +15,14 @@ one of these solutions, e.g.
     import xarray as xr
     import matplotlib.pyplot as plt
 
-    ds = xr.tutorial.load_dataset('rasm').isel(time=slice(0, 3))
+    ds = xr.tutorial.load_dataset('air_temperature').isel(time=slice(0, 3))
     fig, axes = plt.subplots(1, 3, figsize=(8, 4))
 
     for i, ax in enumerate(axes):
-          c = ds.Tair.isel(time=i).plot.pcolormesh(
-              ax=ax, add_colorbar=False, vmin=-30, vmax=30)
+          c = ds.air.isel(time=i).plot.pcolormesh(
+              ax=ax, add_colorbar=False, vmin=230, vmax=305)
     plt.tight_layout()
-    
+
     @savefig example_tair.png
     fig.colorbar(c, ax=axes.ravel().tolist(), orientation='horizontal',
         label='Air temperature');
@@ -118,8 +118,8 @@ If we use these values when plotting we get:
     fig, axes = plt.subplots(1, 3, figsize=(w, 4), sharey=True)
     
     for i, ax in enumerate(axes):
-          c = ds.Tair.isel(time=i).plot.pcolormesh(
-              ax=ax, add_colorbar=False, vmin=-30, vmax=30)
+          c = ds.air.isel(time=i).plot.pcolormesh(
+              ax=ax, add_colorbar=False, vmin=230, vmax=305)
     fig.subplots_adjust(left=left, right=right, wspace=wspace)
     
     @savefig example_tair_adjusted.png
@@ -194,8 +194,8 @@ general:
     fig, axes = plt.subplots(1, 3, figsize=(w, h), sharey=True)
     
     for i, ax in enumerate(axes):
-          c = ds.Tair.isel(time=i).plot.pcolormesh(
-              ax=ax, add_colorbar=False, vmin=-30, vmax=30)
+          c = ds.air.isel(time=i).plot.pcolormesh(
+              ax=ax, add_colorbar=False, vmin=230, vmax=305)
     fig.subplots_adjust(left=left, right=right, wspace=wspace, top=top, bottom=bottom)
     
     @savefig example_tair_adjusted_cbar.png
@@ -236,7 +236,7 @@ the colorbar size parameters:
    
 .. ipython:: python
 
-    a = 75. / 360
+    a = 60. / 130.
     p_cbar = 0.25
     h_panel = a * w_panel
     h = p_bottom + p_top + h_panel + p_cbar + w_cbar
@@ -252,16 +252,15 @@ the colorbar size parameters:
 
     import cartopy.crs as ccrs
 
-    ds = xr.tutorial.load_dataset('rasm').isel(time=slice(0, 3))
     fig, axes = plt.subplots(1, 3, figsize=(w, h),
         subplot_kw={'projection': ccrs.PlateCarree()})
 
     for i, ax in enumerate(axes):
-          c = ds.Tair.isel(time=i).plot.pcolormesh(
-              ax=ax, x='xc', y='yc', add_colorbar=False, vmin=-30, vmax=30,
+          c = ds.air.isel(time=i).plot.pcolormesh(
+              ax=ax, add_colorbar=False, vmin=230, vmax=305,
               transform=ccrs.PlateCarree())
           ax.coastlines()
-          ax.set_extent([-180, 180, 15, 90], crs=ccrs.PlateCarree())
+          ax.set_extent([-160, -30, 15, 75], crs=ccrs.PlateCarree())
 
     fig.subplots_adjust(left=left, right=right, wspace=wspace, top=top, bottom=bottom)
     
@@ -316,11 +315,11 @@ top-level function.
                              axes_kwargs={'projection': ccrs.PlateCarree()})
 
     for i, ax in enumerate(axes):
-          c = ds.Tair.isel(time=i).plot.pcolormesh(
-              ax=ax, x='xc', y='yc', add_colorbar=False, vmin=-30, vmax=30,
+          c = ds.air.isel(time=i).plot.pcolormesh(
+              ax=ax, add_colorbar=False, vmin=230, vmax=305,
               transform=ccrs.PlateCarree())
           ax.coastlines()
-          ax.set_extent([-180, 180, 15, 90], crs=ccrs.PlateCarree())
+          ax.set_extent([-160, -30, 15, 75], crs=ccrs.PlateCarree())
 
      @savefig example_tair_faceted.png     
      plt.colorbar(c, cax=cax, orientation='horizontal',


### PR DESCRIPTION
This fixes a few documentation issues, primarily related to using the latest version of cartopy, but also related to not saving the plots produced in documentation examples to unique files.

For some reason the `"rasm"` tutorial dataset from xarray no longer plots well with cartopy 0.18.0.  

![image](https://user-images.githubusercontent.com/6628425/101281127-63dfc500-379b-11eb-87e8-70c801140bdd.png)

This PR switches things to use the `"air_temperature"` tutorial dataset instead, which does not have this problem.