### PR TITLE
Restore default parameter settings from v0.1

### DIFF
--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -9,6 +9,7 @@ dependencies:
     - nc-time-axis
     - numpy
     - pip
+    - pooch
     - pytest
     - scipy
     - ipython=7.2.0

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -9,6 +9,13 @@ What's New
 v0.3 (unreleased)
 =================
 
+- Defaults for the ``width``, ``height``, and ``aspect`` are now chosen if fewer
+  than two of those are specified in :py:meth:`faceted.faceted`.  This restores
+  the old defaults from version 0.1 without changing the function signature
+  introduced to provide an interface to more varieties of constrained figures in
+  version 0.2.  E.g. calls like ``faceted(1, 1)`` or ``faceted(1, 1, width=5.0)``
+  are now allowed again.
+
 .. _whats-new.0.2:
 
 v0.2 (2020-12-06)

--- a/faceted/faceted.py
+++ b/faceted/faceted.py
@@ -32,13 +32,13 @@ def faceted(
     However, if none or one of them are defined then reasonable defaults are
     selected:
 
-    * If none are provided the width is assumed to be ``8.0`` inches the aspect
+    - If none are provided the width is assumed to be ``8.0`` inches the aspect
       is assumed to be ``0.618``.
-    * If only a ``width`` is provided, the ``aspect`` is assumed to be
+    - If only a ``width`` is provided, the ``aspect`` is assumed to be
       ``0.618``.
-    * If only a ``height`` is provided, the ``aspect`` is assumed to be
+    - If only a ``height`` is provided, the ``aspect`` is assumed to be
       ``0.618``.
-    * If only an ``aspect`` is provided, the ``width`` is assumed to be ``8.0``
+    - If only an ``aspect`` is provided, the ``width`` is assumed to be ``8.0``
       inches.
 
     Parameters
@@ -135,13 +135,13 @@ def faceted_ax(cbar_mode=None, **kwargs):
     However, if none or one of them are defined then reasonable defaults are
     selected:
 
-    * If none are provided the width is assumed to be ``8.0`` inches the aspect
+    - If none are provided the width is assumed to be ``8.0`` inches the aspect
       is assumed to be ``0.618``.
-    * If only a ``width`` is provided, the ``aspect`` is assumed to be
+    - If only a ``width`` is provided, the ``aspect`` is assumed to be
       ``0.618``.
-    * If only a ``height`` is provided, the ``aspect`` is assumed to be
+    - If only a ``height`` is provided, the ``aspect`` is assumed to be
       ``0.618``.
-    * If only an ``aspect`` is provided, the ``width`` is assumed to be ``8.0``
+    - If only an ``aspect`` is provided, the ``width`` is assumed to be ``8.0``
       inches.
 
     Parameters

--- a/faceted/faceted.py
+++ b/faceted/faceted.py
@@ -207,7 +207,9 @@ _BT = ["bottom", "top"]
 
 def _infer_constraints(width, height, aspect):
     if all(constraint is not None for constraint in (width, height, aspect)):
-        raise ValueError("At most two of 'width', 'height', and 'aspect' must be provided.")
+        raise ValueError(
+            "At most two of 'width', 'height', and 'aspect' must be provided."
+        )
     elif all(constraint is None for constraint in (width, height, aspect)):
         return _DEFAULT_WIDTH, None, _DEFAULT_ASPECT
     elif width is not None and height is None and aspect is None:

--- a/faceted/faceted.py
+++ b/faceted/faceted.py
@@ -28,8 +28,18 @@ def faceted(
 ):
     """Create figure and tiled axes objects with precise attributes.
 
-    Exactly two of width, height, and aspect must be defined.  The third is
-    inferred based on the other two values.
+    In general exactly two of width, height, and aspect should be defined.
+    However, if none or one of them are defined then reasonable defaults are
+    selected:
+
+    * If none are provided the width is assumed to be ``8.0`` inches the aspect
+      is assumed to be ``0.618``.
+    * If only a ``width`` is provided, the ``aspect`` is assumed to be
+      ``0.618``.
+    * If only a ``height`` is provided, the ``aspect`` is assumed to be
+      ``0.618``.
+    * If only an ``aspect`` is provided, the ``width`` is assumed to be ``8.0``
+      inches.
 
     Parameters
     ----------
@@ -90,6 +100,7 @@ def faceted(
     if cbar_mode not in [None, "single", "edge", "each"]:
         raise ValueError(f"Invalid cbar mode provided.  Got {cbar_mode}.")
 
+    width, height, aspect = _infer_constraints(width, height, aspect)
     grid_class = _infer_grid_class(width, height, aspect)
     grid = grid_class(
         rows,
@@ -120,8 +131,18 @@ def faceted(
 def faceted_ax(cbar_mode=None, **kwargs):
     """A convenience version of faceted for creating single-axis figures.
 
-    Exactly two of width, height, and aspect must be defined.  The third is
-    inferred based on the other two values.
+    In general exactly two of width, height, and aspect should be defined.
+    However, if none or one of them are defined then reasonable defaults are
+    selected:
+
+    * If none are provided the width is assumed to be ``8.0`` inches the aspect
+      is assumed to be ``0.618``.
+    * If only a ``width`` is provided, the ``aspect`` is assumed to be
+      ``0.618``.
+    * If only a ``height`` is provided, the ``aspect`` is assumed to be
+      ``0.618``.
+    * If only an ``aspect`` is provided, the ``width`` is assumed to be ``8.0``
+      inches.
 
     Parameters
     ----------
@@ -178,18 +199,28 @@ def faceted_ax(cbar_mode=None, **kwargs):
         return fig, ax, cax
 
 
+_DEFAULT_WIDTH = 8.0
+_DEFAULT_ASPECT = 0.618
 _LR = ["left", "right"]
 _BT = ["bottom", "top"]
 
 
-def _assert_valid_constraint(width, height, aspect):
-    constraints = (width, height, aspect)
-    if not (sum(constraint is not None for constraint in constraints) == 2):
-        raise ValueError("Exactly two of width, height, and aspect must be floats")
+def _infer_constraints(width, height, aspect):
+    if all(constraint is not None for constraint in (width, height, aspect)):
+        raise ValueError("At most two of 'width', 'height', and 'aspect' must be provided.")
+    elif all(constraint is None for constraint in (width, height, aspect)):
+        return _DEFAULT_WIDTH, None, _DEFAULT_ASPECT
+    elif width is not None and height is None and aspect is None:
+        return width, None, _DEFAULT_ASPECT
+    elif height is not None and width is None and aspect is None:
+        return None, height, _DEFAULT_ASPECT
+    elif aspect is not None and width is None and height is None:
+        return _DEFAULT_WIDTH, None, aspect
+    else:
+        return width, height, aspect
 
 
 def _infer_grid_class(width, height, aspect):
-    _assert_valid_constraint(width, height, aspect)
     if width is not None and aspect is not None:
         return WidthConstrainedAxesGrid
     elif height is not None and aspect is not None:

--- a/faceted/tests/test_faceted.py
+++ b/faceted/tests/test_faceted.py
@@ -9,8 +9,11 @@ import numpy as np
 import pytest
 
 from ..faceted import (
+    _DEFAULT_ASPECT,
+    _DEFAULT_WIDTH,
     faceted,
     faceted_ax,
+    _infer_constraints,
     _infer_grid_class,
     HeightConstrainedAxesGrid,
     HeightAndWidthConstrainedAxesGrid,
@@ -76,18 +79,26 @@ def test_faceted_invalid_internal_pad():
 
 
 @pytest.mark.parametrize(
-    ("width", "height", "aspect"),
+    ("inputs", "expected"),
     [
-        (None, None, None),
-        (5.0, None, None),
-        (None, 5.0, None),
-        (None, None, 5.0),
-        (5.0, 5.0, 5.0),
+        ((None, None, None), (_DEFAULT_WIDTH, None, _DEFAULT_ASPECT)),
+        ((3.0, None, None), (3.0, None, _DEFAULT_ASPECT)),
+        ((None, 3.0, None), (None, 3.0, _DEFAULT_ASPECT)),
+        ((None, None, 3.0), (_DEFAULT_WIDTH, None, 3.0)),
+        ((3.0, 3.0, None), (3.0, 3.0, None)),
+        ((None, 3.0, 3.0), (None, 3.0, 3.0)),
+        ((3.0, None, 3.0), (3.0, None, 3.0)),
+        ((3.0, 3.0, 3.0), ValueError)
     ],
+    ids=lambda x: str(x)
 )
-def test_faceted_invalid_constraints(width, height, aspect):
-    with pytest.raises(ValueError, match="Exactly"):
-        faceted(1, 2, width=width, height=height, aspect=aspect)
+def test__infer_constraints(inputs, expected):
+    if not isinstance(expected, tuple) and issubclass(expected, Exception):
+        with pytest.raises(expected):
+            _infer_constraints(*inputs)
+    else:
+        result = _infer_constraints(*inputs)
+        assert result == expected
 
 
 @pytest.mark.parametrize(

--- a/faceted/tests/test_faceted.py
+++ b/faceted/tests/test_faceted.py
@@ -88,9 +88,9 @@ def test_faceted_invalid_internal_pad():
         ((3.0, 3.0, None), (3.0, 3.0, None)),
         ((None, 3.0, 3.0), (None, 3.0, 3.0)),
         ((3.0, None, 3.0), (3.0, None, 3.0)),
-        ((3.0, 3.0, 3.0), ValueError)
+        ((3.0, 3.0, 3.0), ValueError),
     ],
-    ids=lambda x: str(x)
+    ids=lambda x: str(x),
 )
 def test__infer_constraints(inputs, expected):
     if not isinstance(expected, tuple) and issubclass(expected, Exception):


### PR DESCRIPTION
Closes #38

This PR implements this suggestion by @chuaxr 

> Another possibility would be to supply defaults if (and only if) there are less than two of the width, height, and aspect arguments. plt.figure provides a default width and height so having defaults doesn't strike me as being 'too magical'.

to restore the default `width` and `aspect` parameters provided in version 0.1 without altering the function signature introduced in version 0.2.