### PR TITLE
Bump version to 2026.07.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ as possible, but retain a fixed aspect ratio (height divided by width).  Maybe
 some (or all) of your panels require an accompanying colorbar.  With
 out of the box `matplotlib` tools this is actually somewhat tricky.
 
-![readme-example.png](readme-example.png?raw=true)
+![](https://raw.githubusercontent.com/spencerkclark/faceted/main/readme-example.png)
 
 Internally, this module uses the flexible [`matplotlib` `AxesGrid` toolkit](https://matplotlib.org/2.0.2/mpl_toolkits/axes_grid/users/overview.html#axes-grid1),
 with some additional logic to enable making these kinds of

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -4,9 +4,9 @@
 What's New
 ##########
 
-.. _whats-new.0.2.2:
+.. _whats-new.2026.07.0:
 
-v0.2.2 (2026-07-03)
+v2026.07.0 (2026-07-03)
 ===================
 
 - Removed workaround for matplotlib colorbar padding issue with ``cbar_mode``

--- a/faceted/faceted.py
+++ b/faceted/faceted.py
@@ -8,7 +8,7 @@ from packaging.version import Version
 from mpl_toolkits.axes_grid1 import AxesGrid
 
 
-__version__ = "0.2.2"
+__version__ = "2026.07.0"
 
 
 def faceted(


### PR DESCRIPTION
This PR updates the README to be compatible with displaying the image on PyPI and switches to using calendar versioning.